### PR TITLE
30 FPS fixes

### DIFF
--- a/ASM/c/fps.c
+++ b/ASM/c/fps.c
@@ -34,11 +34,11 @@ void handle_fps() {
 		z64_fps_limit = 2;
 	
 	if (z64_fps_limit == 2) {
-		if (z64_deku_stick_timer <= 100 && !DEKU_STICK_TIMER_SWITCH) {
+		if (z64_deku_stick_timer == 100 && !DEKU_STICK_TIMER_SWITCH) {
 			z64_deku_stick_timer += 100;
 			DEKU_STICK_TIMER_SWITCH = 1;
 		}
-		if (z64_deku_stick_timer == 0)
+		else if (z64_deku_stick_timer == 0)
 			DEKU_STICK_TIMER_SWITCH = 0;
 		
 		if (z64_link_animation == 0x2968 || z64_link_animation == 0x2970 || z64_link_animation == 0x2A80 || z64_link_animation == 0x2A90)
@@ -72,15 +72,11 @@ void handle_fps() {
 			}
 		}
 		
-		z64_hover_boots_length	= 30;
-		z64_torch_length_1		= 250;
-		z64_torch_length_2		= 275;
-		z64_torch_length_3		= 250;
+		if (z64_hover_boots_length == 19)
+			z64_hover_boots_length	= 30;
 	}
 	else if (z64_fps_limit == 3) {
-		z64_hover_boots_length	= 19;
-		z64_torch_length_1		= 100;
-		z64_torch_length_2		= 110;
-		z64_torch_length_3		= 100;
+		if (z64_hover_boots_length == 30)
+			z64_hover_boots_length	= 19;
 	}
 }

--- a/ASM/c/z64_extended.h
+++ b/ASM/c/z64_extended.h
@@ -34,30 +34,10 @@
 #define z64_time_of_day_speed			(*(uint16_t*)	0x800F1650)
 #define z64_change_scene				(*(uint8_t*)	0x801DB09C)
 #define z64_playing_ocarina				(*(uint8_t*)	0x80102208)
-
+#define z64_hover_boots_length			(*(uint16_t*)	0x8039E612)
 #define z64_timer_type					(*(uint8_t*)	0x8011B99F)
 #define z64_time_remaining				(*(uint16_t*)	0x8011B9A0)
 #define z64_seconds_left				(*(uint8_t*)	0x8011BF31)
-
-#define z64_hover_boots_length			(*(uint16_t*)	0x8039E612)
-// #define z64_hover_boots_length_2		(*(uint16_t*)	0x803A0DBA)
-// #define z64_hover_boots_length_3		(*(uint16_t*)	0x803A0DC0)
-// #define z64_hover_boots_length_4		(*(uint16_t*)	0x803A0DCE)
-// #define z64_hover_boots_length_5		(*(uint16_t*)	0x803A0DFE)
-// #define z64_hover_boots_frames		(*(uint8_t*)	0x801DB2B3)
-// #define z64_hover_boots_active		(*(uint8_t*)	0x801DB2BF)
-
-#define z64_torch_length_1				(*(uint16_t*)	0x801F24E2)
-#define z64_torch_length_2				(*(uint16_t*)	0x801F25E6)
-#define z64_torch_length_3				(*(uint16_t*)	0x801F2826)
-
-// #define z64_bomb_length_1			(*(uint16_t*)	0x80216B46)
-// #define z64_bomb_length_2			(*(uint16_t*)	0x8021707E)
-// #define z64_bomb_length_3			(*(uint16_t*)	0x80217162)
-// #define z64_bomb_length_4			(*(uint16_t*)	0x80217282)
-// #define z64_bomb_length_5			(*(uint16_t*)	0x8021729A)
-
-// #define z64_bombchu_length			(*(uint32_t*)	0x80202C68)
 
 #define z64_fps_1						(*(uint16_t*)	0x801C8C40)
 #define z64_fps_2						(*(uint8_t*)	0x801C8C41)


### PR DESCRIPTION
Fixes:
- Deku Stick not burning properly
- Removes unneeded data
- Removes torch fixes
- Crashes in Kokiri Shop, Castle Courtyard and probably more