### PR TITLE
More Fixes for 30 FPS

### DIFF
--- a/ASM/c/fps.c
+++ b/ASM/c/fps.c
@@ -28,7 +28,7 @@ void handle_fps() {
 		z64_fps_limit = 3;
 	else if (z64_playing_ocarina || (!z64_fps_2 && z64_change_scene == 0x20) )
 		z64_fps_limit = 2;
-	else if (z64_is_demo == 0x80 || z64_control_link == 0 || z64_control_link == 0x4200 || (z64_control_link == 0xFF00 && !z64_talking_to_npc) || z64_hookshot_active == 0x100B || z64_link_animation == 0x2708 || z64_fps_1)
+	else if (z64_is_demo == 0x80 || z64_control_link == 0 || z64_control_link == 0x4200 || (z64_control_link == 0xFF00 && !z64_talking_to_npc) || z64_hookshot_active == 0x100B || z64_link_animation == 0x2708 || z64_fps_1 || z64_bottle_action == 0x00010005)
 		z64_fps_limit = 3;
 	else if (FPS_SWITCH)
 		z64_fps_limit = 2;

--- a/ASM/c/z64_extended.h
+++ b/ASM/c/z64_extended.h
@@ -34,6 +34,7 @@
 #define z64_time_of_day_speed			(*(uint16_t*)	0x800F1650)
 #define z64_change_scene				(*(uint8_t*)	0x801DB09C)
 #define z64_playing_ocarina				(*(uint8_t*)	0x80102208)
+#define z64_bottle_action				(*(uint32_t*)	0x801C86B2)
 #define z64_hover_boots_length			(*(uint16_t*)	0x8039E612)
 #define z64_timer_type					(*(uint8_t*)	0x8011B99F)
 #define z64_time_remaining				(*(uint16_t*)	0x8011B9A0)


### PR DESCRIPTION
Fixes freezes when releasing bugs from bottle by reverting back to 20 FPS mode