### PR TITLE
D-Pad Fixes for masks and icons

### DIFF
--- a/ASM/c/dpad.c
+++ b/ASM/c/dpad.c
@@ -28,7 +28,7 @@ void handle_dpad() {
 	handle_l_button();
 	
 	if (CFG_KEEP_MASK) {
-		if (z64_mask_equipped > 0)
+		if (LAST_MASK != z64_mask_equipped && z64_change_scene != 0x20)
 			LAST_MASK = z64_mask_equipped;
 		if (z64_game.scene_index != LAST_MASK_SCENE && LAST_MASK > 0) {
 			z64_mask_equipped = LAST_MASK;

--- a/ASM/c/dpad_actions.c
+++ b/ASM/c/dpad_actions.c
@@ -484,6 +484,7 @@ void use_ocarina() {
 void draw_sword_icon(z64_disp_buf_t *db, uint16_t alpha, uint16_t icon_x, uint16_t icon_y) {
 	if (z64_file.equip_sword == 0)
 		return;
+	gDPSetPrimColor(db->p++, 0, 0, 0xFF, 0xFF, 0xFF, alpha);
 	sprite_load(db, &items_sprite, (58 + z64_file.equip_sword), 1);
 	sprite_draw(db, &items_sprite, 0, (DPAD_X + icon_x), (DPAD_Y + icon_y), 12, 12);
 }
@@ -491,6 +492,7 @@ void draw_sword_icon(z64_disp_buf_t *db, uint16_t alpha, uint16_t icon_x, uint16
 void draw_shield_icon(z64_disp_buf_t *db, uint16_t alpha, uint16_t icon_x, uint16_t icon_y) {
 	if (z64_file.equip_shield == 0)
 		return;
+	gDPSetPrimColor(db->p++, 0, 0, 0xFF, 0xFF, 0xFF, alpha);
 	sprite_load(db, &items_sprite, (61 + z64_file.equip_shield), 1);
 	sprite_draw(db, &items_sprite, 0, (DPAD_X + icon_x), (DPAD_Y + icon_y), 12, 12);
 }
@@ -498,6 +500,7 @@ void draw_shield_icon(z64_disp_buf_t *db, uint16_t alpha, uint16_t icon_x, uint1
 void draw_tunic_icon(z64_disp_buf_t *db, uint16_t alpha, uint16_t icon_x, uint16_t icon_y) {
 	if (z64_file.equip_tunic == 0)
 		return;
+	gDPSetPrimColor(db->p++, 0, 0, 0xFF, 0xFF, 0xFF, alpha);
 	sprite_load(db, &items_sprite, (64 + z64_file.equip_tunic), 1);
 	sprite_draw(db, &items_sprite, 0, (DPAD_X + icon_x), (DPAD_Y + icon_y), 12, 12);
 }
@@ -506,6 +509,7 @@ void draw_tunic_icon(z64_disp_buf_t *db, uint16_t alpha, uint16_t icon_x, uint16
 void draw_boots_icon(z64_disp_buf_t *db, uint16_t alpha, uint16_t icon_x, uint16_t icon_y) {
 	if (z64_file.equip_boots == 0)
 		return;
+	gDPSetPrimColor(db->p++, 0, 0, 0xFF, 0xFF, 0xFF, alpha);
 	sprite_load(db, &items_sprite, (67 + z64_file.equip_boots), 1);
 	sprite_draw(db, &items_sprite, 0, (DPAD_X + icon_x), (DPAD_Y + icon_y), 12, 12);
 }
@@ -513,6 +517,7 @@ void draw_boots_icon(z64_disp_buf_t *db, uint16_t alpha, uint16_t icon_x, uint16
 void draw_arrow_icon(z64_disp_buf_t *db, uint16_t alpha, uint16_t icon_x, uint16_t icon_y) {
 	for (uint8_t i=1; i<=3; i++) {
 		if (z64_file.button_items[i] == Z64_ITEM_BOW || z64_file.button_items[i] == Z64_ITEM_BOW_FIRE_ARROW || z64_file.button_items[i] == Z64_ITEM_BOW_ICE_ARROW || z64_file.button_items[i] == Z64_ITEM_BOW_LIGHT_ARROW) {
+			gDPSetPrimColor(db->p++, 0, 0, 0xFF, 0xFF, 0xFF, alpha);
 			if (z64_file.button_items[i] == Z64_ITEM_BOW)
 				sprite_load(db, &items_sprite, 0x03, 1);
 			if (z64_file.button_items[i] == Z64_ITEM_BOW_FIRE_ARROW)
@@ -529,6 +534,7 @@ void draw_arrow_icon(z64_disp_buf_t *db, uint16_t alpha, uint16_t icon_x, uint16
 
 void draw_iron_boots_icon(z64_disp_buf_t *db, uint16_t alpha, uint16_t icon_x, uint16_t icon_y) {
 	if (z64_file.iron_boots) {
+		gDPSetPrimColor(db->p++, 0, 0, 0xFF, 0xFF, 0xFF, alpha);
 		sprite_load(db, &items_sprite, 69, 1);
 		if (z64_file.equip_boots == 2)
 			sprite_draw(db, &items_sprite, 0, (DPAD_X + icon_x - 2), (DPAD_Y + icon_y - 2), 16, 16);
@@ -538,6 +544,7 @@ void draw_iron_boots_icon(z64_disp_buf_t *db, uint16_t alpha, uint16_t icon_x, u
 
 void draw_hover_boots_icon(z64_disp_buf_t *db, uint16_t alpha, uint16_t icon_x, uint16_t icon_y) {
 	if (z64_file.hover_boots) {
+		gDPSetPrimColor(db->p++, 0, 0, 0xFF, 0xFF, 0xFF, alpha);
 		sprite_load(db, &items_sprite, 70, 1);
 		if (z64_file.equip_boots == 3)
 			sprite_draw(db, &items_sprite, 0, (DPAD_X + icon_x - 2), (DPAD_Y + icon_y - 2), 16, 16);
@@ -551,7 +558,9 @@ void draw_child_trade_icon(z64_disp_buf_t *db, uint16_t alpha, uint16_t icon_x, 
 			gDPSetPrimColor(db->p++, 0, 0, 0xFF, 0xFF, 0xFF, 0x46);
 		else gDPSetPrimColor(db->p++, 0, 0, 0xFF, 0xFF, 0xFF, alpha);
 		sprite_load(db, &items_sprite, z64_file.items[Z64_SLOT_CHILD_TRADE], 1);
-		sprite_draw(db, &items_sprite, 0, (DPAD_X + icon_x), (DPAD_Y + icon_y), 12, 12);
+		if (z64_mask_equipped > 0)
+			sprite_draw(db, &items_sprite, 0, (DPAD_X + icon_x - 2), (DPAD_Y + icon_y - 2), 16, 16);
+		else sprite_draw(db, &items_sprite, 0, (DPAD_X + icon_x), (DPAD_Y + icon_y), 12, 12);
 	}
 }
 

--- a/ASM/c/dpad_actions.h
+++ b/ASM/c/dpad_actions.h
@@ -2,15 +2,11 @@
 #define DPAD_ACTIONS_H
 
 #include "z64.h"
+#include "z64_extended.h"
 
-#define BLOCK_ITEMS (0x00800000 | \
-                     0x00000800 | \
-                     0x00200000 | \
-                     0x08000000)
-
-#define CAN_USE_OCARINA     (z64_game.pause_ctxt.state == 0 && (z64_file.items[Z64_SLOT_OCARINA] == Z64_ITEM_FAIRY_OCARINA || z64_file.items[Z64_SLOT_OCARINA] == Z64_ITEM_OCARINA_OF_TIME) && !z64_game.restriction_flags.ocarina && ((z64_link.state_flags_1 & BLOCK_ITEMS) == 0))
-#define CAN_USE_CHILD_TRADE (z64_game.pause_ctxt.state == 0 && z64_file.items[Z64_SLOT_CHILD_TRADE] >= Z64_ITEM_WEIRD_EGG && z64_file.items[Z64_SLOT_CHILD_TRADE] <= Z64_ITEM_MASK_OF_TRUTH && !z64_game.restriction_flags.trade_items && ((z64_link.state_flags_1 & BLOCK_ITEMS) == 0))
-#define CAN_USE_ITEMS       (z64_game.pause_ctxt.state == 0 && !z64_game.restriction_flags.all && ((z64_link.state_flags_1 & BLOCK_ITEMS) == 0))
+#define CAN_USE_OCARINA     (z64_game.pause_ctxt.state == 0 && (z64_file.items[Z64_SLOT_OCARINA]     == Z64_ITEM_FAIRY_OCARINA || z64_file.items[Z64_SLOT_OCARINA]     == Z64_ITEM_OCARINA_OF_TIME) && !z64_game.restriction_flags.ocarina     && !z64_link.state_flags_1)
+#define CAN_USE_CHILD_TRADE (z64_game.pause_ctxt.state == 0 && (z64_file.items[Z64_SLOT_CHILD_TRADE] >= Z64_ITEM_WEIRD_EGG     && z64_file.items[Z64_SLOT_CHILD_TRADE] <= Z64_ITEM_MASK_OF_TRUTH)   && !z64_game.restriction_flags.trade_items && !z64_link.state_flags_1)
+#define CAN_USE_ITEMS       (z64_game.pause_ctxt.state == 0 && !z64_game.restriction_flags.all && !z64_link.state_flags_1)
 
 #endif
 

--- a/ASM/c/z64_extended.h
+++ b/ASM/c/z64_extended.h
@@ -3,21 +3,13 @@
 
 #include "z64.h"
 
-/* dram addresses */
-#define z64_camera_view_addr		0x801DB0CD
-#define z64_has_minimap_addr		0x8018884C		// 0x8011B9B3, 8017643C, 8018884C
-#define z64_dungeon_scene_addr		0x801D8BEA
-#define z64_b_button_label_x_addr	0x801C7C3A
-#define z64_b_button_label_y_addr	0x801C7C3E
-#define z64_mask_equipped_addr		0x801DAB7F
-
-/* data */
-#define z64_camera_view			(*(uint8_t*)	z64_camera_view_addr)
-#define z64_has_minimap			(*(uint16_t*)	z64_has_minimap_addr)
-#define z64_dungeon_scene		(*(uint16_t*)	z64_dungeon_scene_addr)
-#define z64_b_button_label_x	(*(uint16_t*)	z64_b_button_label_x_addr)
-#define z64_b_button_label_y	(*(uint16_t*)	z64_b_button_label_y_addr)
-#define z64_mask_equipped		(*(uint8_t*)	z64_mask_equipped_addr)
+/* dram addresses & data*/
+#define z64_camera_view					(*(uint8_t*)	0x801DB0CD)
+#define z64_has_minimap					(*(uint16_t*)	0x8018884C)	// 0x8011B9B3, 8017643C, 8018884C
+#define z64_dungeon_scene				(*(uint16_t*)	0x801D8BEA)
+#define z64_b_button_label_x			(*(uint16_t*)	0x801C7C3A)
+#define z64_b_button_label_y			(*(uint16_t*)	0x801C7C3E)
+#define z64_mask_equipped				(*(uint8_t*)	0x801DAB7F)
 
 /* dram addresses & data for 30 FPS */
 #define z64_fps_limit					(*(uint8_t*)	0x801C6FA1)


### PR DESCRIPTION
Fixes:
- Keep Mask stays off when changing areas when it was unequipped
- Make Trade Quest icon on D-Pad bigger if equipped (mask)
- Alpha for usable / unusable icons on D-Pad does not carry over for the next D-Pad slot but is redefined