### PR TITLE
Deku Nut Fix

### DIFF
--- a/ASM/c/dpad_actions.c
+++ b/ASM/c/dpad_actions.c
@@ -221,7 +221,7 @@ void run_action(uint8_t action) {
 		use_item(Z64_SLOT_OCARINA, CAN_USE_OCARINA);
 	else if (action == DPAD_LENS)
 		use_item(Z64_SLOT_LENS, CAN_USE_ITEMS);
-	else if (action == DPAD_NUT)
+	else if (action == DPAD_NUT && !z64_throwing_nut)
 		use_item(Z64_SLOT_NUT, CAN_USE_ITEMS);
 	else if (action == DPAD_DINS_FIRE)
 		use_item(Z64_SLOT_DINS_FIRE, CAN_USE_ITEMS);

--- a/ASM/c/z64_extended.h
+++ b/ASM/c/z64_extended.h
@@ -79,6 +79,7 @@ typedef struct {
 #define z64_b_button_label_x			(*(uint16_t*)			0x801C7C3A)
 #define z64_b_button_label_y			(*(uint16_t*)			0x801C7C3E)
 #define z64_mask_equipped				(*(uint8_t*)			0x801DAB7F)
+#define z64_throwing_nut				(*(uint8_t*)			0x80124696)
 
 /* DRAM addresses & data for Lens of Truth on D-Pad */
 #define z64_dpad_lens_1					(*(uint16_t*)			0x80072D40)


### PR DESCRIPTION
Deku Nuts can no longer be spammed when on the D-Pad