### PR TITLE
Redux Next Hotfixes April

### DIFF
--- a/ASM/c/buttons.c
+++ b/ASM/c/buttons.c
@@ -3,6 +3,9 @@
 extern uint8_t CFG_WS;
 extern uint8_t CFG_OPTIONS_MENU;
 
+extern uint8_t  compare_frames;
+extern uint16_t play_sfx;
+
 uint8_t hud_hearts_hide		= 1;
 uint8_t hud_counter			= 0;
 uint8_t block_r				= 0;
@@ -19,7 +22,6 @@ uint8_t restore_secs		= 0;
 uint8_t magic_frames		= 0;
 uint8_t magic_secs			= 0;
 uint8_t restore_health		= 0;
-uint16_t last_health		= 0;
 
 void handle_l_button() {
 	if (z64_game.pause_ctxt.state != 0)
@@ -75,10 +77,9 @@ void handle_l_button() {
 void toggle_minimap() {
 	if ( (z64_game.scene_index >= 0x00 && z64_game.scene_index <= 0x09 ) || (z64_game.scene_index >= 0x51 && z64_game.scene_index <= 0x64) ) {
 		z64_gameinfo.minimap_disabled ^= 1;
-		uint16_t sfx = 0x4814;
 		if (z64_gameinfo.minimap_disabled)
-			sfx = 0x4813;
-		z64_playsfx(sfx, (z64_xyzf_t*)0x80104394, 0x04, (float*)0x801043A0, (float*)0x801043A0, (float*)0x801043A8);
+			play_sfx = 0x4813;
+		else play_sfx = 0x4814;;
 	}
 }
 
@@ -88,24 +89,28 @@ void handle_layout() {
 	
 	if (z64_game.pause_ctxt.state == 6) {
 		if (SAVE_HUD_LAYOUT == 2) { // Nintendo
-			if (!CFG_WS)   { z64_c_left_x_set_item = 0x343; z64_c_down_x_set_item = 0x4FB; z64_c_right_x_set_item = 0x1D1; }
-			else           { z64_c_left_x_set_item = 0x54B; z64_c_down_x_set_item = 0x703; z64_c_right_x_set_item = 0x3D9; }
-							 z64_c_left_y_set_item = 0x44C; z64_c_down_y_set_item = 0x492; z64_c_right_y_set_item = 0x352;
+			z64_c_left_x_set_item  = 0x343 + (0x208 * CFG_WS);
+			z64_c_down_x_set_item  = 0x4FB + (0x208 * CFG_WS);
+			z64_c_right_x_set_item = 0x1D1 + (0x208 * CFG_WS);
+			z64_c_left_y_set_item  = 0x44C; z64_c_down_y_set_item = 0x492; z64_c_right_y_set_item = 0x352;
 		}
 		else if (SAVE_HUD_LAYOUT == 3) { // Modern
-			if (!CFG_WS)   { z64_c_left_x_set_item = 0x217; z64_c_down_x_set_item = 0x4FB; z64_c_right_x_set_item = 0x2FD; }
-			else           { z64_c_left_x_set_item = 0x41F; z64_c_down_x_set_item = 0x703; z64_c_right_x_set_item = 0x505; }
-							 z64_c_left_y_set_item = 0x352; z64_c_down_y_set_item = 0x492; z64_c_right_y_set_item = 0x44C;
+			z64_c_left_x_set_item  = 0x217 + (0x208 * CFG_WS);
+			z64_c_down_x_set_item  = 0x4FB + (0x208 * CFG_WS);
+			z64_c_right_x_set_item = 0x2FD + (0x208 * CFG_WS);
+			z64_c_left_y_set_item  = 0x352; z64_c_down_y_set_item = 0x492; z64_c_right_y_set_item = 0x44C;			 
 		}
 		else if (SAVE_HUD_LAYOUT == 4) { // GameCube (Original)
-			if (!CFG_WS)   { z64_c_left_x_set_item = 0x3C0; z64_c_down_x_set_item = 0x4FB; z64_c_right_x_set_item = 0x4FE; }
-			else           { z64_c_left_x_set_item = 0x5C8; z64_c_down_x_set_item = 0x703; z64_c_right_x_set_item = 0x706; }
-							 z64_c_left_y_set_item = 0x4C9; z64_c_down_y_set_item = 0x492; z64_c_right_y_set_item = 0x314;
+			z64_c_left_x_set_item  = 0x3C0 + (0x208 * CFG_WS);
+			z64_c_down_x_set_item  = 0x4FB + (0x208 * CFG_WS);
+			z64_c_right_x_set_item = 0x4FE + (0x208 * CFG_WS);
+			z64_c_left_y_set_item  = 0x4C9; z64_c_down_y_set_item = 0x492; z64_c_right_y_set_item = 0x314;		 
 		}
 		else if (SAVE_HUD_LAYOUT == 5) { // GameCube (Modern)
-			if (!CFG_WS)   { z64_c_left_x_set_item = 0x544; z64_c_down_x_set_item = 0x4FB; z64_c_right_x_set_item = 0x37A; }
-			else           { z64_c_left_x_set_item = 0x74C; z64_c_down_x_set_item = 0x703 ;z64_c_right_x_set_item = 0x582; }
-							 z64_c_left_y_set_item = 0x314; z64_c_down_y_set_item = 0x492; z64_c_right_y_set_item = 0x4C9;
+			z64_c_left_x_set_item  = 0x544 + (0x208 * CFG_WS);
+			z64_c_down_x_set_item  = 0x4FB + (0x208 * CFG_WS);
+			z64_c_right_x_set_item = 0x37A + (0x208 * CFG_WS);
+			z64_c_left_y_set_item = 0x314; z64_c_down_y_set_item = 0x492; z64_c_right_y_set_item = 0x4C9;	 
 		}
 	}
 	
@@ -113,63 +118,63 @@ void handle_layout() {
 		uint16_t a_x = 0, a_y = 0, b_x = 0, b_y = 0, c_left_x = 0, c_left_y = 0, c_down_x = 0, c_down_y = 0, c_right_x = 0, c_right_y = 0, c_up_x = 0, c_up_y = 0;
 		
 		if (SAVE_HUD_LAYOUT == 1) { // Majora's Mask
-			a_x			= 4;	// 186	->	190
-			a_y			= 14;	// 9	->	23
-			b_x			= 7;	// 160	->	167
+			a_x         = 4;   // 186 -> 190
+			a_y         = 14;  // 9   -> 23
+			b_x         = 7;   // 160 -> 167
 		}
 		else if (SAVE_HUD_LAYOUT == 2) { // Nintendo
-			a_x			= 70;	// 186	->	256
-			a_y			= 23;	// 9	->	32
-			b_x			= 80;	// 160	->	240
-			b_y			= 45;	// 11	->	56
-			c_left_x	= 14;	// 227	->	241
-			c_left_y	= 0;	// 18	->	18
-			c_down_x	= 30;	// 249	->	279
-			c_down_y	= -20;	// 34	->	14
-			c_right_x	= -54;	// 271	->	217
-			c_right_y	= 20;	// 18	->	38
-			c_up_x		= 10;	// 254	->	264
-			c_up_y		= -10;	// 16	->	6
+			a_x			= 70;  // 186 -> 256
+			a_y			= 23;  // 9   -> 32
+			b_x			= 80;  // 160 -> 240
+			b_y			= 45;  // 11  -> 56
+			c_left_x	= 14;  // 227 -> 241
+			c_left_y	= 0;   // 18  -> 18
+			c_down_x	= 30;  // 249 -> 279
+			c_down_y	= -20; // 34  -> 14
+			c_right_x	= -54; // 271 -> 217
+			c_right_y	= 20;  // 18  -> 38
+			c_up_x		= 10;  // 254 -> 264
+			c_up_y		= -10; // 16  -> 6
 		}
 		else if (SAVE_HUD_LAYOUT == 3) { // Modern
-			a_x			= 46;	// 186	->	234
-			a_y			= 45;	// 9	->	54
-			b_x			= 104;	// 160	->	264
-			b_y			= 23;	// 11	->	33
-			c_left_x	= -10;	// 227	->	217
-			c_left_y	= 20;	// 18	->	38
-			c_down_x	= 30;	// 249	->	279		
-			c_down_y	= -20;	// 34	->	14		
-			c_right_x	= -30;	// 271	->	241
-			c_right_y	= 0;	// 18	->	18
-			c_up_x		= 10;	// 254	->	264		
-			c_up_y		= -10;	// 16	->	6		
+			a_x         = 46;  // 186 -> 234
+			a_y         = 45;  // 9   -> 54
+			b_x         = 104; // 160 -> 264
+			b_y         = 23;  // 11  -> 33
+			c_left_x    = -10; // 227 -> 217
+			c_left_y    = 20;  // 18  -> 38
+			c_down_x    = 30;  // 249 -> 279		
+			c_down_y    = -20; // 34  -> 14		
+			c_right_x   = -30; // 271 -> 241
+			c_right_y   = 0;   // 18  -> 18
+			c_up_x      = 10;  // 254 -> 264		
+			c_up_y      = -10; // 16  -> 6		
 		}
 		else if (SAVE_HUD_LAYOUT == 4) { // GameCube (Original)
-			a_x			= 55;	// 186	->	241
-			a_y			= 20;	// 9	->	29
-			b_x			= 65;	// 160	->	225
-			b_y			= 40;	// 11	->	51
-			c_left_x	= 24;	// 227	->	251
-			c_left_y	= -10;	// 18	->	8
-			c_down_x	= 30;	// 249	->	279
-			c_down_y	= -20;	// 34	->	14
-			c_right_x	= 11;	// 271	->	282
-			c_right_y	= 25;	// 18	->	43
-			c_up_x		= -20;	// 254	->	234
+			a_x			= 55;  // 186 -> 241
+			a_y			= 20;  // 9   -> 29
+			b_x			= 65;  // 160 -> 225
+			b_y			= 40;  // 11  -> 51
+			c_left_x	= 24;  // 227 -> 251
+			c_left_y	= -10; // 18  -> 8
+			c_down_x	= 30;  // 249 -> 279
+			c_down_y	= -20; // 34  -> 14
+			c_right_x	= 11;  // 271 -> 282
+			c_right_y	= 25;  // 18  -> 43
+			c_up_x		= -20; // 254 -> 234
 		}
 		else if (SAVE_HUD_LAYOUT == 5) { // GameCube (Modern)
-			a_x			= 55;	// 186	->	241
-			a_y			= 20;	// 9	->	29
-			b_x			= 65;	// 160	->	225
-			b_y			= 40;	// 11	->	51
-			c_left_x	= 55;	// 227	->	282
-			c_left_y	= 25;	// 18	->	43
-			c_down_x	= 30;	// 249	->	279
-			c_down_y	= -20;	// 34	->	14
-			c_right_x	= -20;	// 271	->	251
-			c_right_y	= -10;	// 18	->	8
-			c_up_x		= -20;	// 254	->	234
+			a_x			= 55;  // 186 -> 241
+			a_y			= 20;  // 9   -> 29
+			b_x			= 65;  // 160 -> 225
+			b_y			= 40;  // 11  -> 51
+			c_left_x	= 55;  // 227 -> 282
+			c_left_y	= 25;  // 18  -> 43
+			c_down_x	= 30;  // 249 -> 279
+			c_down_y	= -20; // 34  -> 14
+			c_right_x	= -20; // 271 -> 251
+			c_right_y	= -10; // 18  -> 8
+			c_up_x		= -20; // 254 -> 234
 		}
 	
 		z64_gameinfo.a_button_x       += a_x;       z64_gameinfo.a_button_y       += a_y;       z64_gameinfo.a_button_icon_x += a_x;       z64_gameinfo.a_button_icon_y += a_y;
@@ -182,42 +187,35 @@ void handle_layout() {
 }
 
 void reset_layout() {
-	z64_gameinfo.a_button_y			= z64_gameinfo.a_button_icon_y   = 0x9;
-	z64_gameinfo.item_button_y[0]	= z64_gameinfo.item_icon_y[0]    = 0x11;
-	z64_gameinfo.item_ammo_y[0]		= z64_gameinfo.item_ammo_y[1]    = z64_gameinfo.item_ammo_y[3] = 0x23;
-	z64_b_button_label_y			= 0x16;
-	z64_gameinfo.item_button_y[1]	= z64_gameinfo.item_icon_y[1]    = 0x12; z64_gameinfo.item_button_y[2] = z64_gameinfo.item_icon_y[2] = 0x22;
-	z64_gameinfo.item_ammo_y[2]		= 0x33;
-	z64_gameinfo.item_button_y[3]	= z64_gameinfo.item_icon_y[3]    = 0x12;
-	z64_gameinfo.c_up_button_y		= 0x10; z64_gameinfo.c_up_icon_y = 0x14;
+	z64_gameinfo.a_button_y       = z64_gameinfo.a_button_icon_y = 0x9;
+	z64_gameinfo.item_button_y[0] = z64_gameinfo.item_icon_y[0]  = 0x11;
+	z64_gameinfo.item_ammo_y[0]   = z64_gameinfo.item_ammo_y[1]  = z64_gameinfo.item_ammo_y[3] = 0x23;
+	z64_b_button_label_y          = 0x16;
+	z64_gameinfo.item_button_y[1] = z64_gameinfo.item_icon_y[1]  = 0x12;
+	z64_gameinfo.item_button_y[2] = z64_gameinfo.item_icon_y[2]  = 0x22;
+	z64_gameinfo.item_ammo_y[2]   = 0x33;
+	z64_gameinfo.item_button_y[3] = z64_gameinfo.item_icon_y[3]  = 0x12;
+	z64_gameinfo.c_up_button_y    = 0x10;
+	z64_gameinfo.c_up_icon_y      = 0x14;
 	
-	if (!CFG_WS) {
-		z64_gameinfo.a_button_x			= z64_gameinfo.a_button_icon_x   = 0xBA;
-		z64_gameinfo.item_button_x[0]	= z64_gameinfo.item_icon_x[0]    = 0xA2;
-		z64_gameinfo.item_ammo_x[0]		= 0xA4;
-		z64_b_button_label_x			= 0x94;
-		z64_gameinfo.item_ammo_x[1]		= 0xE4;
-		z64_gameinfo.item_button_x[1]	= z64_gameinfo.item_icon_x[1]    = 0xE3; z64_gameinfo.item_button_x[2] = z64_gameinfo.item_icon_x[2] = 0xF9;
-		z64_gameinfo.item_ammo_x[2]		= 0xFA;
-		z64_gameinfo.item_button_x[3]	= z64_gameinfo.item_icon_x[3]    = 0x10F; z64_gameinfo.item_ammo_x[3]  = 0x110;
-		z64_gameinfo.c_up_button_x		= 0xFE; z64_gameinfo.c_up_icon_x = 0xF7;
-	}
-	else {
-		z64_gameinfo.a_button_x			= z64_gameinfo.a_button_icon_x    = 0x122;
-		z64_gameinfo.item_button_x[0]	= z64_gameinfo.item_icon_x[0]     = 0x108;
-		z64_gameinfo.item_ammo_x[0]		= 0x10A;
-		z64_b_button_label_x			= 0xFC;
-		z64_gameinfo.item_ammo_x[1]		= 0x14C;
-		z64_gameinfo.item_button_x[1]	= z64_gameinfo.item_icon_x[1]     = 0x14B; z64_gameinfo.item_button_x[2] = z64_gameinfo.item_icon_x[2] = 0x161;
-		z64_gameinfo.item_ammo_x[2]		= 0x161;
-		z64_gameinfo.item_button_x[3]	= z64_gameinfo.item_icon_x[3]     = 0x177; z64_gameinfo.item_ammo_x[3]   = 0x178;
-		z64_gameinfo.c_up_button_x		= 0x166; z64_gameinfo.c_up_icon_x = 0x15F;
-	}
+	z64_gameinfo.a_button_x       = z64_gameinfo.a_button_icon_x = 0xBA + (0x68 * CFG_WS);
+	z64_gameinfo.item_button_x[0] = z64_gameinfo.item_icon_x[0]  = 0xA2 + (0x66 * CFG_WS);
+	z64_gameinfo.item_ammo_x[0]   = 0xA4  + (0x66 * CFG_WS);
+	z64_b_button_label_x          = 0x94  + (0x68 * CFG_WS);
+	z64_gameinfo.item_ammo_x[1]   = 0xE4  + (0x68 * CFG_WS);
+	z64_gameinfo.item_button_x[1] = z64_gameinfo.item_icon_x[1] = 0xE3 + (0x68 * CFG_WS);
+	z64_gameinfo.item_button_x[2] = z64_gameinfo.item_icon_x[2] = 0xF9 + (0x68 * CFG_WS);
+	z64_gameinfo.item_ammo_x[2]   = 0xFA  + (0x67 * CFG_WS);
+	z64_gameinfo.item_button_x[3] = z64_gameinfo.item_icon_x[3] = 0x10F + (0x68 * CFG_WS);
+	z64_gameinfo.item_ammo_x[3]   = 0x110 + (0x68 * CFG_WS);
+	z64_gameinfo.c_up_button_x    = 0xFE  + (0x68 * CFG_WS);
+	z64_gameinfo.c_up_icon_x      = 0xF7  + (0x68 * CFG_WS);
 	
 	if (z64_game.pause_ctxt.state == 6 && SAVE_HUD_LAYOUT <= 1) {
-		if (!CFG_WS)   { z64_c_left_x_set_item = 0x294; z64_c_down_x_set_item = 0x384; z64_c_right_x_set_item = 0x474; }
-		else           { z64_c_left_x_set_item = 0x49C; z64_c_down_x_set_item = 0x59C; z64_c_right_x_set_item = 0x67C; }
-						 z64_c_left_y_set_item = 0x44C; z64_c_down_y_set_item = 0x398; z64_c_right_y_set_item = 0x44C;
+		z64_c_left_x_set_item  = 0x294 + (0x208 * CFG_WS);
+		z64_c_down_x_set_item  = 0x384 + (0x218 * CFG_WS);
+		z64_c_right_x_set_item = 0x474 + (0x208 * CFG_WS);
+		z64_c_left_y_set_item  = 0x44C; z64_c_down_y_set_item  = 0x398; z64_c_right_y_set_item = 0x44C;
 	}
 }
 
@@ -271,7 +269,7 @@ void set_b_button(pad_t pad_pressed) {
 		else if	(z64_file.link_age)
 			z64_file.child_button_items[0] = item;
 		z64_UpdateItemButton(&z64_game, 0);
-		z64_playsfx(0x4808, (z64_xyzf_t*)0x80104394, 0x04, (float*)0x801043A0, (float*)0x801043A0, (float*)0x801043A8);
+		play_sfx = 0x4808;
 	}
 }
 
@@ -281,9 +279,6 @@ void handle_rupee_dash() {
 	
 	if (z64_file.energy > 1) {
 		rupee_dash_frames++;
-		uint8_t compare_frames = 20;
-		if (fps_limit == 2)
-			compare_frames *= 1.5;
 	
 		if (rupee_dash_frames >= compare_frames) {
 			rupee_dash_frames = 0;
@@ -300,10 +295,9 @@ void handle_rupee_dash() {
 					z64_file.energy -= 4;
 				else z64_file.energy = 1;
 				z64_LinkInvincibility(&z64_link, 0x14);
-				uint16_t sfx = 0x6805;
 				if (z64_file.link_age)
-					sfx = 0x6825;
-				z64_playsfx(sfx, (z64_xyzf_t*)0x80104394, 0x04, (float*)0x801043A0, (float*)0x801043A0, (float*)0x801043A8);
+					play_sfx = 0x6825;
+				else play_sfx = 0x6805;
 			}
 		}
 	}
@@ -340,20 +334,15 @@ void handle_abilities_tunic_colors() {
 		z64_tunic_color = COLOR_FIRE;
 	else if (z64_file.water_medallion && z64_file.equip_tunic == 3)
 		z64_tunic_color = COLOR_WATER;
-	else if (z64_file.shadow_medallion && z64_file.equip_tunic == 0)
-		z64_tunic_color = COLOR_SHADOW;
+	else if (z64_file.equip_tunic == 0)
+		if (z64_file.shadow_medallion)
+			z64_tunic_color = COLOR_SHADOW;
+		else z64_tunic_color = COLOR_NONE;
 }
 
 void handle_abilities() {
 	if (!SAVE_EXTRA_ABILITIES)
 		return;
-	
-	if (restore_health == 0 && z64_damage_frames == 0)
-		last_health = z64_file.energy;
-	
-	uint8_t compare_frames = 20;
-	if (fps_limit == 2)
-		compare_frames *= 1.5;
 	
 	if (z64_file.light_medallion && (z64_file.equip_boots == 1 || (z64_file.spirit_medallion && z64_file.equip_boots == 3) ) && z64_game.common.input[0].raw.pad.l) {
 		if (z64_link_animation_parameter == 0x3FA0)
@@ -370,7 +359,7 @@ void handle_abilities() {
 			if (restore_health == 1) {
 				restore_health = 2;
 				z64_file.magic += 4;
-				z64_playsfx(0x480B, (z64_xyzf_t*)0x80104394, 0x04, (float*)0x801043A0, (float*)0x801043A0, (float*)0x801043A8);
+				play_sfx = 0x480B;
 				
 				if (z64_file.magic > 0x60 && z64_file.magic_capacity)
 					z64_file.magic = 0x60;
@@ -380,24 +369,13 @@ void handle_abilities() {
 		}
 	}
 		
-	if (z64_file.fire_medallion && z64_file.equip_tunic == 2 && HAS_MAGIC && z64_file.magic > 0) {
-		if (z64_damage_frames == 12 && restore_health == 0)
-			restore_health = 1;
-		else if (z64_damage_frames == 0)
-			restore_health = 0;
-		
-		if (restore_health == 1) {
-			restore_health = 2;
-			z64_file.energy += (last_health - z64_file.energy) / 2;
-			z64_playsfx(0x481E, (z64_xyzf_t*)0x80104394, 0x04, (float*)0x801043A0, (float*)0x801043A0, (float*)0x801043A8);
-				
-			if (z64_file.magic >= 4)
-				z64_file.magic -= 4;
-			else z64_file.magic = 0;
-			
-			if (z64_file.energy > z64_file.energy_capacity)
-				z64_file.energy = z64_file.energy_capacity;
-		}
+	if (z64_file.fire_medallion && z64_file.equip_tunic == 2) {
+		z64_damage_taken_modifier_1 = 0x62843;
+		z64_damage_taken_modifier_2 = 0x52C00;
+	}
+	else {
+		z64_damage_taken_modifier_1 = 0x62C00;
+		z64_damage_taken_modifier_2 = 0;
 	}
 		
 	if (z64_file.water_medallion && z64_file.equip_tunic == 3 && z64_sword_damage_1 > 0 && z64_file.equip_sword > 0) {
@@ -421,7 +399,7 @@ void handle_abilities() {
 				if (z64_file.magic >= 4)
 					z64_file.magic -= 4;
 				else z64_file.magic = 0;
-				z64_playsfx(0x480B, (z64_xyzf_t*)0x80104394, 0x04, (float*)0x801043A0, (float*)0x801043A0, (float*)0x801043A8);
+				play_sfx = 0x480B;
 			}
 		}
 		else restore_frames = restore_secs = 0;
@@ -434,17 +412,7 @@ void handle_abilities() {
 	}
 	
 	if (z64_file.kokiris_emerald && (z64_file.equip_boots == 1 || (z64_file.spirit_medallion && z64_file.equip_boots == 3) ) && z64_game.common.input[0].raw.pad.l && HAS_MAGIC && z64_file.magic > 0) {
-		uint16_t extra_speed = 0x50;
-		uint16_t magic_cost  = 2;
-		if (z64_file.gorons_ruby)
-			extra_speed = 0xA0;
-		if (z64_file.zoras_sapphire)
-			magic_cost = 1;
-		
-		uint16_t speed = 0x40B0;
-		if (!z64_file.link_age)
-			speed = 0x40C0;
-		if (z64_move_speed >= speed - 0x1A) {
+		if (z64_move_speed >= z64_max_move_speed - 0x1A) {
 			magic_frames++;
 				
 			if (magic_frames >= compare_frames/2) {
@@ -454,12 +422,12 @@ void handle_abilities() {
 				
 			if (magic_secs >= 1) {
 				magic_secs = 0;
-				if (z64_file.magic >= magic_cost)
-					z64_file.magic -= magic_cost;
+				if (z64_file.magic >= 2 - z64_file.zoras_sapphire)
+					z64_file.magic -= 2 - z64_file.zoras_sapphire;
 				else z64_file.magic = 0;
 			}
 				
-			z64_move_speed = speed + extra_speed;
+			z64_move_speed = z64_max_move_speed + 0x50 + (z64_file.gorons_ruby * 0x50);
 		}
 	}
 	else magic_frames = magic_secs = 0;
@@ -469,10 +437,8 @@ void handle_infinite() {
 	if (z64_game.pause_ctxt.unk_02_[1] != 0)
 		return;
 	
-	if (SAVE_INFINITE_HP) {
-		if (z64_file.energy < z64_file.energy_capacity)
-			z64_file.energy = z64_file.energy_capacity;
-	}
+	if (SAVE_INFINITE_HP)
+		z64_file.energy = z64_file.energy_capacity;
 	
 	if (SAVE_INFINITE_MP) {
 		if (HAS_MAGIC) {
@@ -483,53 +449,16 @@ void handle_infinite() {
 	}
 	
 	if (SAVE_INFINITE_AMMO) {
-		if (z64_file.nut_upgrade == 1)
-			z64_file.ammo[0x01] = z64_capacity.nut_upgrade[1];
-		else if (z64_file.nut_upgrade == 2)
-			z64_file.ammo[0x01] = z64_capacity.nut_upgrade[2];
-		else if (z64_file.nut_upgrade == 3)
-			z64_file.ammo[0x01] = z64_capacity.nut_upgrade[3];
-		
-		if (z64_file.stick_upgrade == 1)
-			z64_file.ammo[0x00] = z64_capacity.stick_upgrade[1];
-		else if (z64_file.stick_upgrade == 2)
-			z64_file.ammo[0x00] = z64_capacity.stick_upgrade[2];
-		else if (z64_file.stick_upgrade == 3)
-			z64_file.ammo[0x00] = z64_capacity.stick_upgrade[3];
-		
-		if (z64_file.bullet_bag == 1)
-			z64_file.ammo[0x06] = z64_capacity.bullet_bag[1];
-		else if (z64_file.bullet_bag == 2)
-			z64_file.ammo[0x06] = z64_capacity.bullet_bag[1];
-		else if (z64_file.bullet_bag == 3)
-			z64_file.ammo[0x06] = z64_capacity.bullet_bag[1];
-		
-		if (z64_file.quiver == 1)
-			z64_file.ammo[0x03] = z64_capacity.quiver[1];
-		else if (z64_file.quiver == 2)
-			z64_file.ammo[0x03] = z64_capacity.quiver[2];
-		else if (z64_file.quiver == 3)
-			z64_file.ammo[0x03] = z64_capacity.quiver[3];
-		
-		if (z64_file.bomb_bag == 1)
-			z64_file.ammo[0x02] = z64_capacity.bomb_bag[1];
-		else if (z64_file.bomb_bag == 2)
-			z64_file.ammo[0x02] = z64_capacity.bomb_bag[2];
-		else if (z64_file.bomb_bag == 3)
-			z64_file.ammo[0x02] = z64_capacity.bomb_bag[3];
+		z64_file.ammo[0x00] = z64_capacity.stick_upgrade[z64_file.stick_upgrade];
+		z64_file.ammo[0x01] = z64_capacity.nut_upgrade[z64_file.nut_upgrade];
+		z64_file.ammo[0x02] = z64_capacity.bomb_bag[z64_file.bomb_bag];
+		z64_file.ammo[0x03] = z64_capacity.quiver[z64_file.quiver];
+		z64_file.ammo[0x06] = z64_capacity.bullet_bag[z64_file.bullet_bag];
 		
 		if (z64_file.items[Z64_SLOT_BOMBCHU] == Z64_ITEM_BOMBCHU)
 			z64_file.ammo[0x08] = 50;
 	}
 	
-	if (SAVE_INFINITE_RUPEES) {
-		if (z64_file.wallet == 0)
-			z64_file.rupees = z64_capacity.wallet[0];
-		else if (z64_file.wallet == 1)
-			z64_file.rupees = z64_capacity.wallet[1];
-		else if (z64_file.wallet == 2)
-			z64_file.rupees = z64_capacity.wallet[2];
-		else if (z64_file.wallet == 3)
-			z64_file.rupees = z64_capacity.wallet[3];
-	}
+	if (SAVE_INFINITE_RUPEES)
+		z64_file.rupees = z64_capacity.wallet[z64_file.wallet];
 }

--- a/ASM/c/dpad.h
+++ b/ASM/c/dpad.h
@@ -7,6 +7,9 @@
 #include <string.h>
 #include <stdio.h>
 
+/* Functions */
+#define z64_playsfx						((playsfx_t)			0x800C806C)
+
 void handle_dpad();
 void handle_dpad_ingame();
 void draw_dpad();

--- a/ASM/c/dpad_actions.h
+++ b/ASM/c/dpad_actions.h
@@ -8,7 +8,7 @@ void change_sword(uint8_t sword);
 void change_shield(uint8_t shield);
 void change_tunic(uint8_t tunic);
 void change_boots(uint8_t boots);
-void change_arrow(uint8_t button, z64_item_t item, uint16_t sfx);
+void change_arrow(uint8_t button, z64_item_t item);
 void change_equipment();
 
 void run_dpad_actions(pad_t pad_pressed);

--- a/ASM/c/dpad_paused.c
+++ b/ASM/c/dpad_paused.c
@@ -1,8 +1,8 @@
 #include "dpad_paused.h"
 
-extern uint8_t dpad_alt;
+extern uint8_t  dpad_alt;
+extern uint16_t play_sfx;
 
-uint8_t knife_counter	= 0xFF;
 uint8_t checked_lens	= 0;
 
 void handle_dpad_paused() {
@@ -77,29 +77,33 @@ void check_lens() {
 	z64_dpad_lens_2 = 0x504F;
 	z64_dpad_lens_3 = 0x5458;
 	
-	if (!z64_file.link_age && !dpad_alt) {
-		unlock_lens(DPAD_ADULT_SET1_UP);
-		unlock_lens(DPAD_ADULT_SET1_RIGHT);
-		unlock_lens(DPAD_ADULT_SET1_DOWN);
-		unlock_lens(DPAD_ADULT_SET1_LEFT);
+	if (!z64_file.link_age) {
+		if (!dpad_alt) {
+			unlock_lens(DPAD_ADULT_SET1_UP);
+			unlock_lens(DPAD_ADULT_SET1_RIGHT);
+			unlock_lens(DPAD_ADULT_SET1_DOWN);
+			unlock_lens(DPAD_ADULT_SET1_LEFT);
+		}
+		else {
+			unlock_lens(DPAD_ADULT_SET2_UP);
+			unlock_lens(DPAD_ADULT_SET2_RIGHT);
+			unlock_lens(DPAD_ADULT_SET2_DOWN);
+			unlock_lens(DPAD_ADULT_SET2_LEFT);
+		}
 	}
-	else if (!z64_file.link_age && dpad_alt) {
-		unlock_lens(DPAD_ADULT_SET2_UP);
-		unlock_lens(DPAD_ADULT_SET2_RIGHT);
-		unlock_lens(DPAD_ADULT_SET2_DOWN);
-		unlock_lens(DPAD_ADULT_SET2_LEFT);
-	}
-	else if (z64_file.link_age && !dpad_alt) {
-		unlock_lens(DPAD_CHILD_SET1_UP);
-		unlock_lens(DPAD_CHILD_SET1_RIGHT);
-		unlock_lens(DPAD_CHILD_SET1_DOWN);
-		unlock_lens(DPAD_CHILD_SET1_LEFT);
-	}
-	else if (z64_file.link_age && dpad_alt) {
-		unlock_lens(DPAD_CHILD_SET2_UP);
-		unlock_lens(DPAD_CHILD_SET2_RIGHT);
-		unlock_lens(DPAD_CHILD_SET2_DOWN);
-		unlock_lens(DPAD_CHILD_SET2_LEFT);
+	else {
+		if (!dpad_alt) {
+			unlock_lens(DPAD_CHILD_SET1_UP);
+			unlock_lens(DPAD_CHILD_SET1_RIGHT);
+			unlock_lens(DPAD_CHILD_SET1_DOWN);
+			unlock_lens(DPAD_CHILD_SET1_LEFT);
+		}
+		else {
+			unlock_lens(DPAD_CHILD_SET2_UP);
+			unlock_lens(DPAD_CHILD_SET2_RIGHT);
+			unlock_lens(DPAD_CHILD_SET2_DOWN);
+			unlock_lens(DPAD_CHILD_SET2_LEFT);
+		}
 	}
 }
 
@@ -114,146 +118,57 @@ void unlock_lens(uint8_t button) {
 void set_dpad_action(pad_t pad_pressed, dpad_action_t action, limit_item_t limit) {
 	if ( (!z64_file.link_age && z64_usability.item[limit] == 1) || (z64_file.link_age && z64_usability.item[limit] == 0) )
 		return;
-	uint16_t sfx = 0x4808;
 	
 	if (pad_pressed.du) {
-		if (!z64_file.link_age && !dpad_alt) {
-			if (DPAD_ADULT_SET1_UP == action) {
-				DPAD_ADULT_UP = DPAD_NULL * 16 + DPAD_ADULT_SET2_UP;
-				sfx = 0x480A;
-			}
-			else DPAD_ADULT_UP = action * 16 + DPAD_ADULT_SET2_UP;
-		}
-		else if (!z64_file.link_age && dpad_alt) {
-			if (DPAD_ADULT_SET2_UP == action) {
-				DPAD_ADULT_UP = DPAD_ADULT_SET1_UP * 16 + DPAD_NULL;
-				sfx = 0x480A;
-			}
-			else DPAD_ADULT_UP = DPAD_ADULT_SET1_UP * 16 + action;
-		}
-		else if (z64_file.link_age  && !dpad_alt) {
-			if (DPAD_CHILD_SET1_UP == action) {
-				DPAD_CHILD_UP = DPAD_NULL * 16 + DPAD_CHILD_SET2_UP;
-				sfx = 0x480A;
-			}
-			else DPAD_CHILD_UP = action * 16 + DPAD_CHILD_SET2_UP;
-		}
-		else if (z64_file.link_age  && dpad_alt) {
-			if (DPAD_CHILD_SET2_UP == action) {
-				DPAD_CHILD_UP = DPAD_CHILD_SET1_UP * 16 + DPAD_NULL;
-				sfx = 0x480A;
-			}
-			else DPAD_CHILD_UP = DPAD_CHILD_SET1_UP * 16 + action;
-		}
+		if (!z64_file.link_age)
+			DPAD_ADULT_UP = run_set_dpad_action(action, DPAD_ADULT_SET1_UP, DPAD_ADULT_SET2_UP);
+		else DPAD_CHILD_UP = run_set_dpad_action(action, DPAD_CHILD_SET1_UP, DPAD_CHILD_SET2_UP);
 	}
 	else if (pad_pressed.dr) {
-		if (!z64_file.link_age && !dpad_alt) {
-			if (DPAD_ADULT_SET1_RIGHT == action) {
-				DPAD_ADULT_RIGHT = DPAD_NULL * 16 + DPAD_ADULT_SET2_RIGHT;
-				sfx = 0x480A;
-			}
-			else DPAD_ADULT_RIGHT = action * 16 + DPAD_ADULT_SET2_RIGHT;
-		}
-		else if (!z64_file.link_age && dpad_alt) {
-			if (DPAD_ADULT_SET2_RIGHT == action) {
-				DPAD_ADULT_RIGHT = DPAD_ADULT_SET1_RIGHT * 16 + DPAD_NULL;
-				sfx = 0x480A;
-			}
-			else DPAD_ADULT_RIGHT = DPAD_ADULT_SET1_RIGHT * 16 + action;
-		}
-		else if (z64_file.link_age  && !dpad_alt) {
-			if (DPAD_CHILD_SET1_RIGHT == action) {
-				DPAD_CHILD_RIGHT = DPAD_NULL * 16 + DPAD_CHILD_SET2_RIGHT;
-				sfx = 0x480A;
-			}
-			else DPAD_CHILD_RIGHT = action * 16 + DPAD_CHILD_SET2_RIGHT;
-		}
-		else if (z64_file.link_age  && dpad_alt) {
-			if (DPAD_CHILD_SET2_RIGHT == action) {
-				DPAD_CHILD_RIGHT = DPAD_CHILD_SET1_RIGHT * 16 + DPAD_NULL;
-				sfx = 0x480A;
-			}
-			else DPAD_CHILD_RIGHT = DPAD_CHILD_SET1_RIGHT * 16 + action;
-		}
+		if (!z64_file.link_age)
+			DPAD_ADULT_RIGHT = run_set_dpad_action(action, DPAD_ADULT_SET1_RIGHT, DPAD_ADULT_SET2_RIGHT);
+		else DPAD_CHILD_RIGHT = run_set_dpad_action(action, DPAD_CHILD_SET1_RIGHT, DPAD_CHILD_SET2_RIGHT);
 	}
 	else if (pad_pressed.dd) {
-		if (!z64_file.link_age && !dpad_alt) {
-			if (DPAD_ADULT_SET1_DOWN == action) {
-				DPAD_ADULT_DOWN = DPAD_NULL * 16 + DPAD_ADULT_SET2_DOWN;
-				sfx = 0x480A;
-			}
-			else DPAD_ADULT_DOWN = action * 16 + DPAD_ADULT_SET2_DOWN;
-		}
-		else if (!z64_file.link_age && dpad_alt) {
-			if (DPAD_ADULT_SET2_DOWN == action) {
-				DPAD_ADULT_DOWN = DPAD_ADULT_SET1_DOWN * 16 + DPAD_NULL;
-				sfx = 0x480A;
-			}
-			else DPAD_ADULT_DOWN = DPAD_ADULT_SET1_DOWN * 16 + action;
-		}
-		else if (z64_file.link_age  && !dpad_alt) {
-			if (DPAD_CHILD_SET1_DOWN == action) {
-				DPAD_CHILD_DOWN = DPAD_NULL * 16 + DPAD_CHILD_SET2_DOWN;
-				sfx = 0x480A;
-			}
-			else DPAD_CHILD_DOWN = action * 16 + DPAD_CHILD_SET2_DOWN;
-		}
-		else if (z64_file.link_age  && dpad_alt) {
-			if (DPAD_CHILD_SET2_DOWN == action) {
-				DPAD_CHILD_DOWN = DPAD_CHILD_SET1_DOWN * 16 + DPAD_NULL;
-				sfx = 0x480A;
-			}
-			else DPAD_CHILD_DOWN = DPAD_CHILD_SET1_DOWN * 16 + action;
-		}
+		if (!z64_file.link_age)
+			DPAD_ADULT_DOWN = run_set_dpad_action(action, DPAD_ADULT_SET1_DOWN, DPAD_ADULT_SET2_DOWN);
+		else DPAD_CHILD_DOWN = run_set_dpad_action(action, DPAD_CHILD_SET1_DOWN, DPAD_CHILD_SET2_DOWN);
 	}
 	else if (pad_pressed.dl) {
-		if (!z64_file.link_age && !dpad_alt) {
-			if (DPAD_ADULT_SET1_LEFT == action) {
-				DPAD_ADULT_LEFT = DPAD_NULL * 16 + DPAD_ADULT_SET2_LEFT;
-				sfx = 0x480A;
-			}
-			else DPAD_ADULT_LEFT = action * 16 + DPAD_ADULT_SET2_LEFT;
-		}
-		else if (!z64_file.link_age && dpad_alt) {
-			if (DPAD_ADULT_SET2_LEFT == action) {
-				DPAD_ADULT_LEFT = DPAD_ADULT_SET1_LEFT * 16 + DPAD_NULL;
-				sfx = 0x480A;
-			}
-			else DPAD_ADULT_LEFT = DPAD_ADULT_SET1_LEFT * 16 + action;
-		}
-		else if (z64_file.link_age  && !dpad_alt) {
-			if (DPAD_CHILD_SET1_LEFT == action) {
-				DPAD_CHILD_LEFT = DPAD_NULL * 16 + DPAD_CHILD_SET2_LEFT;
-				sfx = 0x480A;
-			}
-			else DPAD_CHILD_LEFT = action * 16 + DPAD_CHILD_SET2_LEFT;
-		}
-		else if (z64_file.link_age  && dpad_alt) {
-			if (DPAD_CHILD_SET2_LEFT == action) {
-				DPAD_CHILD_LEFT = DPAD_CHILD_SET1_LEFT * 16 + DPAD_NULL;
-				sfx = 0x480A;
-			}
-			else DPAD_CHILD_LEFT = DPAD_CHILD_SET1_LEFT * 16 + action;
-		}
+		if (!z64_file.link_age)
+			DPAD_ADULT_LEFT = run_set_dpad_action(action, DPAD_ADULT_SET1_LEFT, DPAD_ADULT_SET2_LEFT);
+		else DPAD_CHILD_LEFT = run_set_dpad_action(action, DPAD_CHILD_SET1_LEFT, DPAD_CHILD_SET2_LEFT);
 	}
+}
+
+uint8_t run_set_dpad_action(dpad_action_t action, uint8_t set1, uint8_t set2) {
+	if (action == DPAD_LENS)
+		checked_lens = 0;
 	
-	if (pad_pressed.du || pad_pressed.dr || pad_pressed.dd || pad_pressed.dl) {
-		if (action == DPAD_LENS)
-			checked_lens = 0;
-		z64_playsfx(sfx, (z64_xyzf_t*)0x80104394, 0x04, (float*)0x801043A0, (float*)0x801043A0, (float*)0x801043A8);
+	if (!dpad_alt)
+		 return run_set_dpad_action_set(action, set1, DPAD_NULL, set2, action, set2);
+	return run_set_dpad_action_set(action, set2, set1, DPAD_NULL, set1, action);
+}
+
+uint8_t run_set_dpad_action_set(dpad_action_t action, uint8_t set, uint8_t btn1, uint8_t btn2, uint8_t btn3, uint8_t btn4) {
+	if (set == action) {
+		play_sfx = 0x480A;
+		return btn1 * 16 + btn2;
 	}
+	play_sfx = 0x4808;
+	return btn3 * 16 + btn4;
 }
 
 void handle_unequipping(pad_t pad_pressed) {
 	if (z64_game.pause_ctxt.screen_idx == 3 && pad_pressed.a) {
 		if (SAVE_UNEQUIP_GEAR) { // Unequip gear
-			if ( (z64_game.pause_ctxt.equip_cursor == 1  && z64_file.equip_sword  == 1) || (z64_game.pause_ctxt.equip_cursor == 2  && z64_file.equip_sword  == 2) || (z64_game.pause_ctxt.equip_cursor == 3  && z64_file.equip_sword  == 3) )
+			if (z64_game.pause_ctxt.equip_cursor     == z64_file.equip_sword)
 				unequip_sword(1);
-			if ( (z64_game.pause_ctxt.equip_cursor == 5  && z64_file.equip_shield == 1) || (z64_game.pause_ctxt.equip_cursor == 6  && z64_file.equip_shield == 2) || (z64_game.pause_ctxt.equip_cursor == 7  && z64_file.equip_shield == 3) )
+			if (z64_game.pause_ctxt.equip_cursor - 4 == z64_file.equip_shield)
 				unequip_shield();
 		}
 		if (SAVE_EXTRA_ABILITIES || SAVE_UNEQUIP_GEAR)
-			if ( (z64_game.pause_ctxt.equip_cursor == 9  && z64_file.equip_tunic  == 1) || (z64_game.pause_ctxt.equip_cursor == 10 && z64_file.equip_tunic  == 2) || (z64_game.pause_ctxt.equip_cursor == 11 && z64_file.equip_tunic  == 3) )
+			if (z64_game.pause_ctxt.equip_cursor - 8 == z64_file.equip_tunic)
 				unequip_tunic();
 	}
 	
@@ -288,7 +203,7 @@ void handle_unequipping(pad_t pad_pressed) {
 								z64_file.child_button_items[button]			= 0xFF;
 								z64_file.child_c_button_slots[button - 1]	= 0xFF;
 							}
-							z64_playsfx(0x480A, (z64_xyzf_t*)0x80104394, 0x04, (float*)0x801043A0, (float*)0x801043A0, (float*)0x801043A8);
+							play_sfx = 0x480A;
 							break;
 						}
 					}
@@ -299,21 +214,28 @@ void handle_unequipping(pad_t pad_pressed) {
 }
 
 void handle_downgrading() {
-	if (!SAVE_DOWNGRADE_ITEM || z64_game.pause_ctxt.state != 6 || z64_game.pause_ctxt.unk_02_[1] != 0 || !z64_game.common.input[0].pad_pressed.cu)
+	if (!SAVE_DOWNGRADE_ITEM || z64_game.pause_ctxt.state != 6 || z64_game.pause_ctxt.unk_02_[1] != 0)
+		return;
+	
+	if ( (z64_file.broken_giants_knife && z64_file.bgs_hits_left > 0) ||  (!z64_file.broken_giants_knife && z64_file.bgs_hits_left == 0) )
+		z64_file.broken_giants_knife ^= 1;
+	
+	if (!z64_game.common.input[0].pad_pressed.cu)
 		return;
 	
 	if (z64_game.pause_ctxt.screen_idx == 3) { // Swap knife
 		if (z64_game.pause_ctxt.equip_cursor == 3 && (DOWNGRADE_GIANTS_KNIFE || z64_file.bgs_flag) ) {
-			EXTRA_SRAM_1		|= 2;
-			z64_file.bgs_flag	^= 1;
+			if (!DOWNGRADE_GIANTS_KNIFE)
+				EXTRA_SRAM_1 |= 2;
+			
+			z64_file.bgs_flag ^= 1;
 			if (!z64_file.bgs_flag)
-				if (knife_counter != 0xFF)
-					z64_file.bgs_hits_left = knife_counter;
-			else knife_counter = z64_file.bgs_hits_left;
+				z64_file.bgs_hits_left = SWORD_HEALTH;
+
 			if (z64_file.equip_sword == 3)
 				unequip_sword(0);
 			z64_UpdateEquipment(&z64_game, &z64_link);
-			z64_playsfx(0x4808, (z64_xyzf_t*)0x80104394, 0x04, (float*)0x801043A0, (float*)0x801043A0, (float*)0x801043A8);
+			play_sfx = 0x4808;
 		}
 	}
 			
@@ -340,15 +262,15 @@ void swap_item(z64_slot_t slot, z64_item_t item, z64_item_t swap) {
 	if (z64_file.items[slot] == item) {
 		for (uint8_t i=0; i<4; i++) {
 			if (z64_file.button_items[i] == item) {
-				z64_file.button_items[i]			= swap;
+				z64_file.button_items[i]            = swap;
 				if (!z64_file.link_age)
-					z64_file.adult_button_items[i]	= swap;
-				else z64_file.child_button_items[i]	= swap;
+					z64_file.adult_button_items[i]  = swap;
+				else z64_file.child_button_items[i] = swap;
 				z64_UpdateItemButton(&z64_game, i);
 			}
 		}
 		z64_file.items[slot] = swap;
-		z64_playsfx(0x4808, (z64_xyzf_t*)0x80104394, 0x04, (float*)0x801043A0, (float*)0x801043A0, (float*)0x801043A8);
+		play_sfx = 0x4808;
 	}
 }
 
@@ -356,31 +278,31 @@ void unequip_gear(uint8_t play) {
 	z64_game.common.input[0].raw.pad.a = z64_game.common.input[0].pad_pressed.a = 0;
 	z64_UpdateEquipment(&z64_game, &z64_link);
 	if (play)
-		z64_playsfx(0x480A, (z64_xyzf_t*)0x80104394, 0x04, (float*)0x801043A0, (float*)0x801043A0, (float*)0x801043A8);
+		play_sfx = 0x480A;
 }
 
 void unequip_sword(uint8_t play) {
-	z64_file.equip_sword				= 0;
+	z64_file.equip_sword            = 0;
 	if (z64_file.link_age)
-		z64_file.child_equip_sword		= 0;
-	else z64_file.adult_equip_sword		= 0;
-	z64_file.inf_table[29]				= 1;
-	z64_file.button_items[0]			= -1;
+		z64_file.child_equip_sword  = 0;
+	else z64_file.adult_equip_sword = 0;
+	z64_file.inf_table[29]          = 1;
+	z64_file.button_items[0]        = -1;
 	unequip_gear(play);
 }
 
 void unequip_shield() {
-	z64_file.equip_shield				= 0;
+	z64_file.equip_shield            = 0;
 	if (z64_file.link_age)
-		z64_file.child_equip_shield		= 0;
-	else z64_file.adult_equip_shield	= 0;
+		z64_file.child_equip_shield  = 0;
+	else z64_file.adult_equip_shield = 0;
 	unequip_gear(1);
 }
 
 void unequip_tunic() {
-	z64_file.equip_tunic				= 0;
+	z64_file.equip_tunic            = 0;
 	if (z64_file.link_age)
-		z64_file.child_equip_tunic		= 0;
-	else z64_file.adult_equip_tunic		= 0;
+		z64_file.child_equip_tunic  = 0;
+	else z64_file.adult_equip_tunic = 0;
 	unequip_gear(1);
 }

--- a/ASM/c/dpad_paused.h
+++ b/ASM/c/dpad_paused.h
@@ -7,8 +7,11 @@
 void handle_dpad_paused();
 void handle_dpad_slots(pad_t pad_pressed);
 void check_lens();
+void run_unlock_lens(uint8_t up, uint8_t right, uint8_t down, uint8_t left);
 void unlock_lens(uint8_t button);
 void set_dpad_action(pad_t pad_pressed, dpad_action_t action, limit_item_t restriction);
+uint8_t run_set_dpad_action(dpad_action_t action, uint8_t set1, uint8_t set2);
+uint8_t run_set_dpad_action_set(dpad_action_t action, uint8_t set, uint8_t btn1, uint8_t btn2, uint8_t btn3, uint8_t btn4);
 void handle_unequipping(pad_t pad_pressed);
 void handle_downgrading();
 void swap_item(z64_slot_t slot, z64_item_t original, z64_item_t swap);

--- a/ASM/c/fps.c
+++ b/ASM/c/fps.c
@@ -7,6 +7,8 @@ uint8_t  damage_frames_timer_switch	= 0;
 uint16_t last_time					= 0;
 uint16_t started_timer				= 0;
 
+extern uint16_t play_sfx;
+
 void handle_fps() {
 	if (!SAVE_30_FPS || z64_game.pause_ctxt.state != 0 || z64_file.game_mode != 0)
 		return;
@@ -14,8 +16,8 @@ void handle_fps() {
 	if ( (z64_game.common.input[0].raw.pad.l && z64_game.common.input[0].pad_pressed.z) || (z64_game.common.input[0].raw.pad.z && z64_game.common.input[0].pad_pressed.l) ) {
 		fps_switch ^= 1;
 		if (fps_switch)
-			z64_playsfx(0x4814, (z64_xyzf_t*)0x80104394, 0x04, (float*)0x801043A0, (float*)0x801043A0, (float*)0x801043A8);
-		else z64_playsfx(0x4813, (z64_xyzf_t*)0x80104394, 0x04, (float*)0x801043A0, (float*)0x801043A0, (float*)0x801043A8);
+			play_sfx = 0x4814;
+		else play_sfx = 0x4813;
 	}
 	
 	if (!fps_switch)

--- a/ASM/c/gfx.c
+++ b/ASM/c/gfx.c
@@ -109,9 +109,9 @@ sprite_t subscreen_sprite = {
     G_IM_FMT_IA, G_IM_SIZ_8b, 1
 };
 
-sprite_t subscreen_en_sprite = {
-    NULL, 80, 32, 9,
-    G_IM_FMT_IA, G_IM_SIZ_8b, 1
+sprite_t item_name_sprite = {
+    NULL, 128, 16, 9,
+    G_IM_FMT_IA, G_IM_SIZ_4b, 1
 };
 
 sprite_t title_sprite = {
@@ -191,6 +191,11 @@ void gfx_init() {
     };
     file_init(&subscreen_static);
 	
+	file_t item_name_static = {
+        NULL, 0x00880000, 0x03D800
+    };
+    file_init(&item_name_static);
+	
     stones_sprite.buf = title_static.buf + 0x2A300;
     medals_sprite.buf = title_static.buf + 0x2980;
     items_sprite.buf = icon_item_static.buf;
@@ -206,6 +211,7 @@ void gfx_init() {
     counter_digit_sprite.buf = parameter_static.buf + 0x3040;
     ammo_digit_sprite.buf = parameter_static.buf + 0x35C0;
     subscreen_sprite.buf = subscreen_static.buf;
+	item_name_sprite.buf = item_name_static.buf + 0x38400;
     title_sprite.buf = title_static.buf + 0x2D700;
 	
     int font_bytes = sprite_bytes(&font_sprite);

--- a/ASM/c/options.c
+++ b/ASM/c/options.c
@@ -2,114 +2,37 @@
 #include "text.h"
 #include "options.h"
 #include "buttons.h"
+#include "dpad_paused.h"
 #include "fps.h"
 
 extern uint8_t CFG_WS;
 extern uint8_t CFG_OPTIONS_MENU;
 
-uint8_t options_menu		= 0;
-uint8_t moved_axis_option	= 0;
-uint8_t options_frames		= 0;
-uint8_t holding_stick		= 0;
+extern uint16_t play_sfx;
 
-char options[OPTIONS_SIZE_ALL][OPTIONS_LENGTH]	= { "30 FPS",  "D-Pad Config", "D-Pad Layout", "Hide HUD", "HUD Layout", "Inverse Aim", "No Idle Camera", "Keep Mask", "Tri-Swipe", "Unequip Item", "Unequip Gear", "Item on B", "Downgrade Item", "Crouch Stab Fix", "Weaker Swords", "Extra Abilities", "Rupee Drain", "Fog", "Inventory Editor", "Levitation", "Infinite Health", "Infinite Magic", "Infinite Rupees", "Infinite Ammo" };
-uint8_t options_max[OPTIONS_SIZE_ALL]			= { 0,         2,              3,              4,          5,            0,             0,                0,           0,           0,              0,              0,           0,                0,                 0,               0,                 15,            15,    0,                  0,             0,                0,                0,                 0               };
-int8_t  options_recenter[OPTIONS_SIZE_ALL]		= { 40,        15,             15,             30,         22,           17,            5,                25,          25,          15,             15,             27,          5,                0,                 10,              0,                 20,            50,    -5,                 20,            0,                5,                0,                 10              };
-uint8_t options_cursor							= 0;
+uint8_t options_menu      = 0;
+uint8_t moved_axis_option = 0;
+uint8_t options_frames    = 0;
+uint8_t holding_stick     = 0;
 
-char tooltips1[OPTIONS_SIZE_ALL][30] = {
-	"Allows 30 FPS, press L and",
-	"0. Disabled",
-	"0. Hidden",
-	"Choose from four different",
-	"Choose from five different",
-	"Inverse y-axis for analog",
-	"The camera no longer moves",
-	"Mask remains equipped upon",
-	"Replaces the transition",
-	"Unassign items using the",
-	"Unassign equipment by",
-	"Assign items to the B",
-	"Change between previously",
-	"The Crouch Stab move no",
-	"Sword slashes now deal one",
-	"Obtain Spiritual Stones",
-	"First drains rupees, then",
-	"Adjust the level of fog",
-	"Open the Inventory Editor",
-	"Hold the L button to",
-	"Your Health is kept at",
-	"Your Magic is kept at",
-	"Your Rupees are kept at",
-	"Your Ammo is kept at"
-};
-
-char tooltips2[OPTIONS_SIZE_ALL][30] = {
-	"Z to toggle between 30 FPS",
-	"1. Enabled",
-	"1. Left",
-	"options to hide the HUD",
-	"layouts to change the HUD",
-	"controls when aiming in",
-	"behind Link during idle",
-	"entering another area",
-	"effect with a twirling",
-	"respective C button",
-	"pressing A",
-	"button by pressing A",
-	"obtained items by pressing",
-	"longer keeps the last",
-	"less point of damage",
-	"and Medallions to earn new",
-	"health based on set",
-	"applied, with higher",
-	"subscreen and adjust all",
-	"levitate",
-	"current maximum limit",
-	"current maximum limit",
-	"current maximum limit",
-	"current maximum limit"
-};
-
-char tooltips3[OPTIONS_SIZE_ALL][30] = {
-	"and 20 FPS mode",
-	"2. Dual Set",
-	"2. Right",
-	"",
-	"",
-	"first-person view",
-	"stance",
-	"",
-	"Triforce animation",
-	"",
-	"",
-	"",
-	"the C-Up button",
-	"dealt damage",
-	"",
-	"abilities",
-	"seconds",
-	"values increasing the fog",
-	"of your items",
-	"",
-	"",
-	"",
-	"",
-	""
-};
+char medallion_item[9][17]                 = { "Light Medallion", "Forest Medallion", "Fire Medallion", "Water Medallion", "Shadow Medallion", "Spirit Medallion", "Kokiri's Emerald", "Goron's Ruby", "Zora's Sapphire" };
+char medallion_ability[9][16]              = { "Long Jump",       "Magician Tunic",   "Guardian Tunic", "Hero Tunic",      "Shadow Tunic",     "Hover Dash Jump",  "Dash",             "Faster Dash",  "Cheaper Dash"    };
+char options[OPTIONS_SIZE_ALL][17]         = { "30 FPS", "D-Pad Config", "D-Pad Layout", "Hide HUD", "HUD Layout", "Inverse Aim", "No Idle Camera", "Keep Mask", "Tri-Swipe", "Damage Taken", "Unequip Item", "Unequip Gear", "Item on B", "Downgrade Item", "Crouch Stab Fix", "Weaker Swords", "Extra Abilities", "Rupee Drain", "Fog", "Inventory Editor", "Levitation", "Infinite Health", "Infinite Magic", "Infinite Rupees", "Infinite Ammo" };
+uint8_t options_max[OPTIONS_SIZE_ALL]      = { 0,        2,              3,              4,          5,            0,             0,                0,           0,           7,              0,              0,              0,           0,                0,                 0,               0,                 15,            15,    0,                  0,             0,                0,                0,                 0               };
+int8_t  options_recenter[OPTIONS_SIZE_ALL] = { 40,       15,             15,             30,         22,           17,            5,                25,          25,          15,             15,             15,             27,          5,                0,                 10,              0,                 20,            50,    -5,                 20,            0,                5,                0,                 10              };
+uint8_t options_cursor                     = 0;
 
 void toggle_options_menu() {
 	if (z64_game.pause_ctxt.state != 6 || !z64_game.common.input[0].pad_pressed.l)
 		return;
 	
-	uint16_t sfx = 0x4813;
+	play_sfx = 0x4813;
 	if (z64_game.pause_ctxt.unk_02_[1] == 0)
 		z64_game.pause_ctxt.unk_02_[1] = 3;
 	else {
 		z64_game.pause_ctxt.unk_02_[1] = 0;
-		sfx = 0x4814;
+		play_sfx = 0x4814;
 	}
-	z64_playsfx(sfx, (z64_xyzf_t*)0x80104394, 0x04, (float*)0x801043A0, (float*)0x801043A0, (float*)0x801043A8);
 }
 
 void handle_options_menu() {
@@ -133,7 +56,7 @@ void handle_options_menu() {
 		if (options_cursor == 0)
 			options_cursor = size - 1;
 		else options_cursor--;
-		z64_playsfx(0x4839, (z64_xyzf_t*)0x80104394, 0x04, (float*)0x801043A0, (float*)0x801043A0, (float*)0x801043A8);
+		play_sfx = 0x4839;
 		
 		if (z64_x_axis_input < -50)
 			moved_axis_option = 1;
@@ -142,13 +65,13 @@ void handle_options_menu() {
 		if (options_cursor == size - 1)
 			options_cursor = 0;
 		else options_cursor++;
-		z64_playsfx(0x4839, (z64_xyzf_t*)0x80104394, 0x04, (float*)0x801043A0, (float*)0x801043A0, (float*)0x801043A8);
+		play_sfx = 0x4839;
 		
 		if (z64_x_axis_input > 50)
 			moved_axis_option = 1;
 	}
 	else if (pad_pressed.a  || pad_pressed.b) {
-		z64_playsfx(0x483B, (z64_xyzf_t*)0x80104394, 0x04, (float*)0x801043A0, (float*)0x801043A0, (float*)0x801043A8);
+		play_sfx = 0x483B;
 		handle_options_menu_input(pad_pressed);
 	}
 	
@@ -188,92 +111,59 @@ void handle_options_menu_input(pad_t pad_pressed) {
 			z64_game.common.input[0].raw.pad.a = z64_game.common.input[0].pad_pressed.a = 0;
 			z64_game.common.input[0].raw.pad.b = z64_game.common.input[0].pad_pressed.b = 0;
 			return;
+			
+		case OPTION_DAMAGE_TAKEN:
+			EXTRA_SRAM_6 = write_option(SAVE_DAMAGE_TAKEN, EXTRA_SRAM_6, 0, pad_pressed);
+			return;
+			
+		case OPTION_RUPEE_DRAIN:
+			EXTRA_SRAM_3 = write_option(SAVE_RUPEE_DRAIN,  EXTRA_SRAM_3, 0, pad_pressed);
+			return;
+		
+		case OPTION_HIDE_HUD:
+			EXTRA_SRAM_3 = write_option(SAVE_HIDE_HUD,     EXTRA_SRAM_3, 4, pad_pressed);
+			return;
+		
+		case OPTION_DPAD:
+			EXTRA_SRAM_4 = write_option(SAVE_DPAD,         EXTRA_SRAM_4, 0, pad_pressed);
+			if (SAVE_DPAD == 0)
+				{ z64_dpad_lens_1 = 0x504E; z64_dpad_lens_2 = 0x504F; z64_dpad_lens_3 = 0x5458; }
+			else check_lens();
+			return;
+		
+		case OPTION_SHOW_DPAD:
+			EXTRA_SRAM_4 = write_option(SAVE_SHOW_DPAD,    EXTRA_SRAM_4, 2, pad_pressed);
+			return;
+		
+		case OPTION_HUD_LAYOUT:
+			EXTRA_SRAM_4 = write_option(SAVE_HUD_LAYOUT,   EXTRA_SRAM_4, 4, pad_pressed);
+			reset_layout();
+			return;
+		
+		case OPTION_FOG:
+			EXTRA_SRAM_5 = write_option(SAVE_FOG,          EXTRA_SRAM_5, 0, pad_pressed);
+			if (SAVE_FOG == 0)
+				z64_game.fog_distance = 10.0f;
+			return;
 	}
+}
+
+uint8_t write_option(uint8_t save, uint8_t sram, uint8_t shift, pad_t pad_pressed) {
+	int8_t max = options_max[options_cursor] << shift;
+	int8_t one = 1 << shift;
 	
 	if (pad_pressed.a) {
-		switch (options_cursor) {
-			case OPTION_RUPEE_DRAIN:
-				if (SAVE_RUPEE_DRAIN < options_max[options_cursor])
-					EXTRA_SRAM_3++;
-				else EXTRA_SRAM_3 -= options_max[options_cursor];
-				return;
-			
-			case OPTION_HIDE_HUD:
-				if (SAVE_HIDE_HUD < options_max[options_cursor])
-					EXTRA_SRAM_3 += 1 << 4;
-				else EXTRA_SRAM_3 -= options_max[options_cursor] << 4;
-				return;
-			
-			case OPTION_DPAD:
-				if (SAVE_DPAD < options_max[options_cursor])
-					EXTRA_SRAM_4++;
-				else EXTRA_SRAM_4 -= options_max[options_cursor];
-				return;
-			
-			case OPTION_SHOW_DPAD:
-				if (SAVE_SHOW_DPAD < options_max[options_cursor])
-					EXTRA_SRAM_4 += 1 << 2;
-				else EXTRA_SRAM_4 -= options_max[options_cursor] << 2;
-				return;
-			
-			case OPTION_HUD_LAYOUT:
-				if (SAVE_HUD_LAYOUT < options_max[options_cursor])
-					EXTRA_SRAM_4 += 1 << 4;
-				else EXTRA_SRAM_4 -= options_max[options_cursor] << 4;
-				reset_layout();
-				return;
-			
-			case OPTION_FOG:
-				if (SAVE_FOG < options_max[options_cursor])
-					EXTRA_SRAM_5++;
-				else EXTRA_SRAM_5 -= options_max[options_cursor];
-				if (SAVE_FOG == 0)
-					z64_game.fog_distance = 10.0f;
-				return;
-		}
+		if (save < options_max[options_cursor])
+			sram += one;
+		else sram -= max;
 	}
 	else {
-		switch (options_cursor) {
-			case OPTION_RUPEE_DRAIN:
-				if (SAVE_RUPEE_DRAIN > 0)
-					EXTRA_SRAM_3--;
-				else EXTRA_SRAM_3 += options_max[options_cursor];
-				return;
-			
-			case OPTION_HIDE_HUD:
-				if (SAVE_HIDE_HUD > 0)
-					EXTRA_SRAM_3 -= 1 << 4;
-				else EXTRA_SRAM_3 += options_max[options_cursor] << 4;
-				return;
-			
-			case OPTION_DPAD:
-				if (SAVE_DPAD > 0)
-					EXTRA_SRAM_4--;
-				else EXTRA_SRAM_4 += options_max[options_cursor];
-				return;
-			
-			case OPTION_SHOW_DPAD:
-				if (SAVE_SHOW_DPAD > 0)
-					EXTRA_SRAM_4 -= 1 << 2;
-				else EXTRA_SRAM_4 += options_max[options_cursor] << 2;
-				return;
-			
-			case OPTION_HUD_LAYOUT:
-				if (SAVE_HUD_LAYOUT > 0)
-					EXTRA_SRAM_4 -= 1 << 4;
-				else EXTRA_SRAM_4 += options_max[options_cursor] << 4;
-				reset_layout();
-				return;
-				
-			case OPTION_FOG:
-				if (SAVE_FOG > 0)
-					EXTRA_SRAM_5--;
-				else EXTRA_SRAM_5 += options_max[options_cursor];
-				if (SAVE_FOG == 0)
-					z64_game.fog_distance = 10.0f;
-				return;
-		}
+		if (save > 0)
+			sram -= one;
+		else sram += max;
 	}
+	
+	return sram;
 }
 
 uint8_t draw_settings_menu(z64_disp_buf_t *db) {
@@ -281,34 +171,30 @@ uint8_t draw_settings_menu(z64_disp_buf_t *db) {
 		return 0;
 	
 	gDPSetCombineMode(db->p++, G_CC_MODULATEIA_PRIM, G_CC_MODULATEIA_PRIM);
-	gDPSetPrimColor(db->p++, 0, 0, 0xFF, 0xFF, 0xFF, 0xFF);
 	
-	uint8_t x			= 40;
-	uint8_t y			= 40;
-	uint8_t width		= 80;
-	uint8_t height		= 32;
-	uint8_t left		= 98;
-	uint8_t top			= 75;
-	uint8_t setting		= 0;
+	uint8_t x = 40;
+	if (CFG_WS)
+		x += 52;
 	
-	if (CFG_WS) {
-		x		+= 52;
-		left	+= 52;
-	}
+	uint8_t y                = 40;
+	uint8_t top              = 75;
+	uint8_t left             = x + 58;
+	uint8_t setting	         = 0;
+	uint8_t tooltipLeft      = left - 45;
+	uint8_t width            = 80;
+	uint8_t height           = 32;
 	
-	gDPSetCombineMode(db->p++, G_CC_MODULATEIA_PRIM, G_CC_MODULATEIA_PRIM);
-		
-	gDPSetPrimColor(db->p++, 0, 0, 0xFF, 0xFF, 0xFF, 0);
-	sprite_load(db, &stones_sprite, 0, 1);
-	sprite_draw(db, &stones_sprite, 0, 0, 0, 16, 16);
+	// Subscreen
+	sprite_load(db, &stones_sprite, 0, 1);				// Fake Load
+	sprite_draw(db, &stones_sprite, -10, -10, 0, 4, 4); // Fake Draw
 	
 	gDPSetPrimColor(db->p++, 0, 0, 0xA0, 0xA0, 0xA0, 0xFF);
 	sprite_load(db, &subscreen_sprite, 4,  1);
-	sprite_draw(db, &subscreen_sprite, 0, x,               y, width, height);
+	sprite_draw(db, &subscreen_sprite, 0, x,         y, width, height);
 	sprite_load(db, &subscreen_sprite, 66, 1);
-	sprite_draw(db, &subscreen_sprite, 0, x + width,       y, width, height);
+	sprite_draw(db, &subscreen_sprite, 0, x + width, y, width, height);
 	sprite_load(db, &subscreen_sprite, 5,  1);
-	sprite_draw(db, &subscreen_sprite, 0, x + (width * 2), y, width, height);
+	sprite_draw(db, &subscreen_sprite, 0, x + 160,   y, width, height);
 	
 	for (uint8_t i=0; i<3; i++)
 		for (uint8_t j=1; j<=4; j++) {
@@ -316,66 +202,201 @@ uint8_t draw_settings_menu(z64_disp_buf_t *db) {
 			sprite_draw(db, &subscreen_sprite, 0, x + (width * i), y + (height * j), width, height);
 		}
 	
-	gDPSetPrimColor(db->p++, 0, 0, 0xFF, 0xFF, 0xFF, 0xFF);
-	sprite_load(db, &title_sprite, 9, 1);
-	sprite_draw(db, &title_sprite, 0, x + width + 16, y + 3, 128, 16);
-	
 	gDPSetPrimColor(db->p++, 0, 0, 0xD0, 0xD0, 0xD0, 0xFF);
 	sprite_load(db, &button_sprite, 2, 1);
 	sprite_draw(db, &button_sprite, 0, left - 35,  top - 10, 32, 32);
 	sprite_load(db, &button_sprite, 4, 1);
 	sprite_draw(db, &button_sprite, 0, left + 120, top - 10, 32, 32);
 	
-	switch (options_cursor) {
-		case OPTION_30_FPS:				setting = SAVE_30_FPS;			break;
-		case OPTION_DPAD:				setting = SAVE_DPAD;			break;
-		case OPTION_SHOW_DPAD:			setting = SAVE_SHOW_DPAD;		break;
-		case OPTION_HIDE_HUD:			setting = SAVE_HIDE_HUD;		break;
-		case OPTION_HUD_LAYOUT:			setting = SAVE_HUD_LAYOUT;		break;
-		case OPTION_INVERSE_AIM:		setting = SAVE_INVERSE_AIM;		break;
-		case OPTION_NO_IDLE_CAMERA:		setting = SAVE_NO_IDLE_CAMERA;	break;
-		case OPTION_KEEP_MASK:			setting = SAVE_KEEP_MASK;		break;
-		case OPTION_TRISWIPE:			setting = SAVE_TRISWIPE;		break;
-		case OPTION_UNEQUIP_ITEM:		setting = SAVE_UNEQUIP_ITEM;	break;
-		case OPTION_UNEQUIP_GEAR:		setting = SAVE_UNEQUIP_GEAR;	break;
-		case OPTION_ITEM_ON_B:			setting = SAVE_ITEM_ON_B;		break;
-		case OPTION_DOWNGRADE_ITEM:		setting = SAVE_DOWNGRADE_ITEM;	break;
-		case OPTION_CROUCH_STAB_FIX:	setting = SAVE_CROUCH_STAB_FIX;	break;
-		case OPTION_WEAKER_SWORDS:		setting = SAVE_WEAKER_SWORDS;	break;
-		case OPTION_EXTRA_ABILITIES:	setting = SAVE_EXTRA_ABILITIES; break;
-		case OPTION_RUPEE_DRAIN:		setting = SAVE_RUPEE_DRAIN;		break;
-		case OPTION_FOG:				setting = SAVE_FOG;				break;
-		case OPTION_LEVITATION:			setting = SAVE_LEVITATION;		break;
-		case OPTION_INFINITE_HP:		setting = SAVE_INFINITE_HP;		break;
-		case OPTION_INFINITE_MP:		setting = SAVE_INFINITE_MP;		break;
-		case OPTION_INFINITE_RUPEES:	setting = SAVE_INFINITE_RUPEES;	break;
-		case OPTION_INFINITE_AMMO:		setting = SAVE_INFINITE_AMMO;	break;
-	}
+	gDPSetPrimColor(db->p++, 0, 0, 0xFF, 0xFF, 0xFF, 0xFF);
+	sprite_load(db, &title_sprite, 9, 1);
+	sprite_draw(db, &title_sprite, 0, x + 96, y + 3, 128, 16);
 	
+	// Options Text
+	switch (options_cursor) {
+		case OPTION_30_FPS:
+			setting = SAVE_30_FPS;
+			text_print("Allows 30 FPS, press L and",  tooltipLeft, top + 50);
+			text_print("Z to toggle between 30 FPS",  tooltipLeft, top + 70);
+			text_print("and 20 FPS mode",             tooltipLeft, top + 90);
+			break;
+		
+		case OPTION_DPAD:
+			setting = SAVE_DPAD;
+			text_print("0. Disabled",                 tooltipLeft, top + 50);
+			text_print("1. Enabled",                  tooltipLeft, top + 70);
+			text_print("2. Dual Set",                 tooltipLeft, top + 90);
+			break;
+		
+		case OPTION_SHOW_DPAD:
+			setting = SAVE_SHOW_DPAD;
+			text_print("0. Hidden, 1. Left",         tooltipLeft, top + 50);
+			text_print("2. Right,  3. Bottom",       tooltipLeft, top + 70);
+			break;
+		
+		case OPTION_HIDE_HUD:
+			setting = SAVE_HIDE_HUD;
+			text_print("Choose from four different",  tooltipLeft, top + 50);
+			text_print("options to hide the HUD",     tooltipLeft, top + 70);
+			break;
+		
+		case OPTION_HUD_LAYOUT:
+			setting = SAVE_HUD_LAYOUT;	
+			text_print("Choose from five different",  tooltipLeft, top + 50);
+			text_print("layouts to change the HUD",   tooltipLeft, top + 70);
+			break;
+		
+		case OPTION_INVERSE_AIM:
+			setting = SAVE_INVERSE_AIM;	
+			text_print("Inverse y-axis for analog",   tooltipLeft, top + 50);
+			text_print("controls when aiming in",     tooltipLeft, top + 70);
+			text_print("first-person view",           tooltipLeft, top + 90);
+			break;
+		
+		case OPTION_NO_IDLE_CAMERA:
+			setting = SAVE_NO_IDLE_CAMERA;	
+			text_print("The camera no longer moves",  tooltipLeft, top + 50);
+			text_print("behind Link during idle",     tooltipLeft, top + 70);
+			text_print("stance",                      tooltipLeft, top + 90);
+			break;
+		
+		case OPTION_KEEP_MASK:
+			setting = SAVE_KEEP_MASK;	
+			text_print("Mask remains equipped upon",  tooltipLeft, top + 50);
+			text_print("entering another area",       tooltipLeft, top + 70);
+			break;
+		
+		case OPTION_TRISWIPE:
+			setting = SAVE_TRISWIPE;	
+			text_print("Replaces the transition",     tooltipLeft, top + 50);
+			text_print("effect with a twirling",      tooltipLeft, top + 70);
+			text_print("Triforce animation",          tooltipLeft, top + 90);
+			break;
+		
+		case OPTION_DAMAGE_TAKEN:
+			if (SAVE_DAMAGE_TAKEN > 0)
+				setting = 1 << (SAVE_DAMAGE_TAKEN-1);
+			text_print("Multiplies taken damage",     tooltipLeft, top + 50);
+			text_print("by the factor shown below",   tooltipLeft, top + 70);
+			text_print("0 = Off",                     tooltipLeft, top + 90);
+			break;
+		
+		case OPTION_UNEQUIP_ITEM:
+			setting = SAVE_UNEQUIP_ITEM;	
+			text_print("Unassign items using the",    tooltipLeft, top + 50);
+			text_print("respective C button",         tooltipLeft, top + 70);
+			break;
+		
+		case OPTION_UNEQUIP_GEAR:
+			setting = SAVE_UNEQUIP_GEAR;
+			text_print("Unassign equipment by",       tooltipLeft, top + 50);
+			text_print("pressing A",                  tooltipLeft, top + 70);
+			break;
+		
+		case OPTION_ITEM_ON_B:
+			setting = SAVE_ITEM_ON_B;	
+			text_print("Assign items to the B",       tooltipLeft, top + 50);
+			text_print("button by pressing A",        tooltipLeft, top + 70);
+			break;
+		
+		case OPTION_DOWNGRADE_ITEM:
+			setting = SAVE_DOWNGRADE_ITEM;	
+			text_print("Change between previously",   tooltipLeft, top + 50);
+			text_print("obtained items by pressing",  tooltipLeft, top + 70);
+			text_print("the C-Up button",             tooltipLeft, top + 90);
+			break;
+		
+		case OPTION_CROUCH_STAB_FIX:
+			setting = SAVE_CROUCH_STAB_FIX;	
+			text_print("The Crouch Stab move no",     tooltipLeft, top + 50);
+			text_print("longer keeps the last",       tooltipLeft, top + 70);
+			text_print("dealt damage",                tooltipLeft, top + 90);
+			break;
+		
+		case OPTION_WEAKER_SWORDS:
+			setting = SAVE_WEAKER_SWORDS;
+			text_print("Sword slashes now deal one",  tooltipLeft, top + 50);
+			text_print("less point of damage",        tooltipLeft, top + 70);
+			break;
+		
+		case OPTION_EXTRA_ABILITIES:
+			setting = SAVE_EXTRA_ABILITIES; 
+			text_print("Obtain Spiritual Stones",     tooltipLeft, top + 50);
+			text_print("and Medallions to earn new",  tooltipLeft, top + 70);
+			text_print("abilities",                   tooltipLeft, top + 90);
+			break;
+		
+		case OPTION_RUPEE_DRAIN:
+			setting = SAVE_RUPEE_DRAIN;		
+			text_print("First drains rupees, then",   tooltipLeft, top + 50);
+			text_print("health based on set",         tooltipLeft, top + 70);
+			text_print("seconds",                     tooltipLeft, top + 90);
+			break;
+		
+		case OPTION_FOG:
+			setting = SAVE_FOG;		
+			text_print("Adjust the level of fog",     tooltipLeft, top + 50);
+			text_print("applied, with higher",        tooltipLeft, top + 70);
+			text_print("values increasing the fog",   tooltipLeft, top + 90);
+			break;
+		
+		case OPTION_INVENTORY_EDITOR:
+			text_print("Open the Inventory Editor",   tooltipLeft, top + 50);
+			text_print("subscreen and adjust all",    tooltipLeft, top + 70);
+			text_print("of your items",               tooltipLeft, top + 90);
+			break;
+		
+		case OPTION_LEVITATION:
+			setting = SAVE_LEVITATION;
+			text_print("Hold the L button to",        tooltipLeft, top + 50);
+			text_print("levitate",                    tooltipLeft, top + 70);
+			break;
+		
+		case OPTION_INFINITE_HP:
+			setting = SAVE_INFINITE_HP;	
+			text_print("Your Health is kept at",      tooltipLeft, top + 50);
+			break;
+		
+		case OPTION_INFINITE_MP:
+			setting = SAVE_INFINITE_MP;
+			text_print("Your Magic is kept at",       tooltipLeft, top + 50);
+			break;
+		
+		case OPTION_INFINITE_RUPEES:
+			setting = SAVE_INFINITE_RUPEES;	
+			text_print("Your Rupees are kept at",     tooltipLeft, top + 50);
+			break;
+		
+		case OPTION_INFINITE_AMMO:
+			setting = SAVE_INFINITE_AMMO;
+			text_print("Your Ammo is kept at",        tooltipLeft, top + 50);
+			break;
+	}
+	if (options_cursor >= OPTION_INFINITE_HP && options_cursor <= OPTION_INFINITE_AMMO)
+		text_print("current maximum limit", tooltipLeft, top + 70);
+	
+	text_flush(db);
+	
+	// Options Value & Title
 	if (setting == 0)
-		 gDPSetPrimColor(db->p++, 0, 0, 0xFF, 0xFF, 0xFF, 0xFF);
+		gDPSetPrimColor(db->p++, 0, 0, 0xFF, 0xFF, 0xFF, 0xFF);
 	else gDPSetPrimColor(db->p++, 0, 0, 0x00, 0xFF, 0x00, 0xFF);
 	
 	if (options_cursor != OPTION_INVENTORY_EDITOR) {
-		if (setting < 10) {
-			sprite_load(db, &ammo_digit_sprite, setting, 1);
-			sprite_draw(db, &ammo_digit_sprite, 0, left + 56, top + 20, 16, 16);
-		}
-		else {
-			sprite_load(db, &ammo_digit_sprite, 1, 1);
+		sprite_load(db, &stones_sprite, 0, 1);				// Fake Load
+		sprite_draw(db, &stones_sprite, -10, -10, 0, 4, 4); // Fake Draw
+		
+		uint8_t adjust = 8;
+		if (setting >= 10) {
+			sprite_load(db, &ammo_digit_sprite, (setting / 10), 1);
 			sprite_draw(db, &ammo_digit_sprite, 0, left + 48, top + 20, 16, 16);
-			sprite_load(db, &ammo_digit_sprite, (setting - 10), 1);
-			sprite_draw(db, &ammo_digit_sprite, 0, left + 64, top + 20, 16, 16);
+			adjust = 0;
 		}
+		sprite_load(db, &ammo_digit_sprite, (setting % 10), 1);
+		sprite_draw(db, &ammo_digit_sprite, 0, left + 64 - adjust, top + 20, 16, 16);
 	}
 	
 	text_print(options[options_cursor],  left + options_recenter[options_cursor], top);
-	text_flush(db);
-	
-	gDPSetPrimColor(db->p++, 0, 0, 0xFF, 0xFF, 0xFF, 0xFF);
-	text_print(tooltips1[options_cursor], left - 45, top + 50);
-	text_print(tooltips2[options_cursor], left - 45, top + 70);
-	text_print(tooltips3[options_cursor], left - 45, top + 90);
 	text_flush(db);
 	
 	return 1;
@@ -385,129 +406,108 @@ uint8_t draw_abilities_info(z64_disp_buf_t *db) {
 	if (!SAVE_EXTRA_ABILITIES || !IS_PAUSE_SCREEN_CURSOR || z64_game.pause_ctxt.screen_idx != 2 || !z64_game.common.input[0].raw.pad.a)
 		return 0;
 	
-	uint8_t show         = 0;
-	char str_item[26]    = "";
-	char str_ability[25] = "";
-	char str_desc1[30]   = "";
-	char str_desc2[30]   = "";
-	char str_desc3[30]   = "";
-	char str_desc4[30]   = "";
+	uint8_t show;
 	
-	if (z64_game.pause_ctxt.quest_cursor == 5 && z64_file.light_medallion) { // Light Medallion
-		strcpy(str_item,    "Item:    Light Medallion");
-		strcpy(str_ability, "Ability: Long Jump");
-		strcpy(str_desc1,   "Run, hold L and");
-		strcpy(str_desc1,   "press A to jump");
-		strcpy(str_desc3,   "Requires the Kokiri Boots");
-		strcpy(str_desc4,   "for it to be effective");
-		show = 1;
-	}
-	else if (z64_game.pause_ctxt.quest_cursor == 0 && z64_file.forest_medallion) { // Forest Medallion
-		strcpy(str_item,    "Item:    Forest Medallion");
-		strcpy(str_ability, "Ability: Magician Tunic");
-		strcpy(str_desc1,   "Restores some magic when hit");
-		strcpy(str_desc2,   "Replaces the Kokiri Tunic and");
-		strcpy(str_desc3,   "requires to be equipped");
-		show = 1;
-	}
-	else if (z64_game.pause_ctxt.quest_cursor == 1 && z64_file.fire_medallion) { // Fire Medallion
-		strcpy(str_item,    "Item:    Fire Medallion");
-		strcpy(str_ability, "Ability: Guardian Tunic");
-		strcpy(str_desc1,   "Restores half of the damage");
-		strcpy(str_desc2,   "taken at the cost of magic");
-		strcpy(str_desc3,   "Replaces the Goron Tunic and");
-		strcpy(str_desc4,   "requires to be equipped");
-		show = 1;
-	}
-	else if (z64_game.pause_ctxt.quest_cursor == 2 && z64_file.water_medallion) { // Water Medallion
-		strcpy(str_item,    "Item:    Water Medallion");
-		strcpy(str_ability, "Ability: Hero Tunic");
-		strcpy(str_desc1,   "Increases damage done by");
-		strcpy(str_desc2,   "sword slashes by +1");
-		strcpy(str_desc3,   "Replaces the Zora Tunic and");
-		strcpy(str_desc4,   "requires to be equipped");
-		show = 1;
-	}
-	else if (z64_game.pause_ctxt.quest_cursor == 4 && z64_file.shadow_medallion) { // Shadow Medallion
-		strcpy(str_item,    "Item:    Shadow Medallion");
-		strcpy(str_ability, "Ability: Shadow Tunic");
-		strcpy(str_desc1,   "Restores some health over");
-		strcpy(str_desc2,   "time at the cost of magic");
-		strcpy(str_desc3,   "Unequip the tunic with C-Up");
-		strcpy(str_desc4,   "for it to be effective");
-		show = 1;
-	}
-	else if (z64_game.pause_ctxt.quest_cursor == 3 && z64_file.spirit_medallion) { // Spirit Medallion
-		strcpy(str_item,    "Item:    Spirit Medallion");
-		strcpy(str_ability, "Ability: Hover Dash Jump");
-		strcpy(str_desc1,   "The Jump and Dash abilities");
-		strcpy(str_desc1,   "can now be used with the");
-		strcpy(str_desc3,   "Hover Boots as well");
-		show = 1;
-	}
-	else if (z64_game.pause_ctxt.quest_cursor == 0x12 && z64_file.kokiris_emerald) { // Kokiri's Emerald
-		strcpy(str_item,    "Item:    Kokiri's Emerald");
-		strcpy(str_ability, "Ability: Dash");
-		strcpy(str_desc1,   "Hold L when running to dash");
-		strcpy(str_desc2,   "Consumes magic");
-		strcpy(str_desc3,   "Requires the Kokiri Boots");
-		strcpy(str_desc4,   "for it to be effective");
-		show = 1;
-	}
-	else if (z64_game.pause_ctxt.quest_cursor == 0x13 && z64_file.gorons_ruby) { // Goron's Ruby
-		strcpy(str_item,    "Item:    Goron's Ruby");
-		strcpy(str_ability, "Ability: Faster Dash");
-		strcpy(str_desc1,   "Upgrades the Dash Ability ");
-		strcpy(str_desc2,   "to be faster");
-		show = 1;
-	}
-	else if (z64_game.pause_ctxt.quest_cursor == 0x14 && z64_file.zoras_sapphire) { // Zora's Sapphire
-		strcpy(str_item,    "Item:    Zora's Sapphire");
-		strcpy(str_ability, "Ability: Cheaper Dash");
-		strcpy(str_desc1,   "Lower the magic cost of");
-		strcpy(str_desc2,   "the dash ability");
-		show = 1;
-	}
+	if      (z64_game.pause_ctxt.quest_cursor == 5    && z64_file.light_medallion)  { show = 0; } // Light Medallion
+	else if (z64_game.pause_ctxt.quest_cursor == 0    && z64_file.forest_medallion) { show = 1; } // Forest Medallion
+	else if (z64_game.pause_ctxt.quest_cursor == 1    && z64_file.fire_medallion)   { show = 2; } // Fire Medallion
+	else if (z64_game.pause_ctxt.quest_cursor == 2    && z64_file.water_medallion)  { show = 3; } // Water Medallion
+	else if (z64_game.pause_ctxt.quest_cursor == 4    && z64_file.shadow_medallion) { show = 4; } // Shadow Medallion
+	else if (z64_game.pause_ctxt.quest_cursor == 3    && z64_file.spirit_medallion) { show = 5; } // Spirit Medallion
+	else if (z64_game.pause_ctxt.quest_cursor == 0x12 && z64_file.kokiris_emerald)  { show = 6; } // Kokiri's Emerald
+	else if (z64_game.pause_ctxt.quest_cursor == 0x13 && z64_file.gorons_ruby)      { show = 7; } // Goron's Ruby
+	else if (z64_game.pause_ctxt.quest_cursor == 0x14 && z64_file.zoras_sapphire)   { show = 8; } // Zora's Sapphire
+	else return 0;
 	
-	if (show) {
-		int left   = 10;
-		int top    = 10;
-		int width  = 240;
-		int height = 115;
+	uint8_t left     = 15;
+	uint8_t leftInfo = 85;
+	uint8_t info1    = 55;
+	uint8_t info2    = 72;
+	uint8_t info3    = 89;
+	uint8_t info4    = 106;
+	
+	gDPSetCombineMode(db->p++, G_CC_PRIMITIVE, G_CC_PRIMITIVE);
+	gDPSetPrimColor(db->p++, 0, 0, 0x00, 0x00, 0x00, 0xD0);
+	gSPTextureRectangle(db->p++,
+		10<<2,  10<<2,
+		250<<2, 125<<2,
+		0,
+		0, 0,
+		1<<10, 1<<10);
 		
-		gDPSetCombineMode(db->p++, G_CC_PRIMITIVE, G_CC_PRIMITIVE);
-		
-		gDPSetPrimColor(db->p++, 0, 0, 0x00, 0x00, 0x00, 0xD0);
-		gSPTextureRectangle(db->p++,
-			left<<2,            top<<2,
-			(left + width)<<2, (top + height)<<2,
-			0,
-			0, 0,
-			1<<10, 1<<10);
-		
-		gDPSetCombineMode(db->p++, G_CC_MODULATEIA_PRIM, G_CC_MODULATEIA_PRIM);
-		
-		gDPSetPrimColor(db->p++, 0, 0, 0xFF, 0, 0, 0xFF);
-		text_print(str_item,    left + 5, top + 5);
-		text_flush(db);
-		
-		gDPSetPrimColor(db->p++, 0, 0, 0xFF, 0, 0, 0xFF);
-		text_print(str_ability, left + 5, top + 25);
-		text_flush(db);
-		
-		gDPSetPrimColor(db->p++, 0, 0, 0xFF, 0xFF, 0xFF, 0xFF);
-		text_print(str_desc1,   left + 5, top + 45);
-		text_print(str_desc2,   left + 5, top + 62);
-		text_print(str_desc3,   left + 5, top + 79);
-		text_print(str_desc4,   left + 5, top + 96);
-		text_flush(db);
-		
-		gDPFullSync(db->p++);
-		gSPEndDisplayList(db->p++);
-		
-		return 1;
+	gDPSetCombineMode(db->p++, G_CC_MODULATEIA_PRIM, G_CC_MODULATEIA_PRIM);
+	
+	gDPSetPrimColor(db->p++, 0, 0, 0xFF, 0xFF, 0xFF, 0xFF);
+	switch (show) {
+		case 0: // Light Medallion
+			text_print("Run, hold L and",               left, info1);
+			text_print("press A to jump",               left, info2);
+			text_print("Requires the Kokiri Boots",     left, info3);
+			text_print("for it to be effective",        left, info4);
+			break;
+				
+		case 1: // Forest Medallion
+			text_print("Restores some magic when hit",  left, info1);
+			text_print("Replaces the Kokiri Tunic and", left, info2);
+			text_print("requires to be equipped",       left, info3);
+			break;
+				
+		case 2: // Fire Medallion
+			text_print("Reduces damage taken by half",  left, info1);
+			text_print("Replaces the Goron Tunic and",  left, info2);
+			text_print("requires to be equipped",       left, info3);
+			break;
+				
+		case 3: // Water Medallion
+			text_print("Increases damage done by",      left, info1);
+			text_print("sword slashes by +1",           left, info2);
+			text_print("Replaces the Zora Tunic and",   left, info3);
+			text_print("requires to be equipped",       left, info4);
+			break;
+				
+		case 4: // Shadow Medallion
+			text_print("Restores some health over",     left, info1);
+			text_print("time at the cost of magic",     left, info2);
+			text_print("Unequip the tunic with C-Up",   left, info3);
+			text_print("for it to be effective",        left, info4);
+			break;
+				
+		case 5: // Spirit Medallion
+			text_print("The Jump and Dash abilities",   left, info1);
+			text_print("can now be used with the",      left, info2);
+			text_print("Hover Boots as well",           left, info3);
+			break;
+				
+		case 6: // Kokiri's Emerald
+			text_print("Hold L when running to dash",   left, info1);
+			text_print("Consumes magic",                left, info2);
+			text_print("Requires the Kokiri Boots",     left, info3);
+			text_print("for it to be effective",        left, info4);
+			break;
+				
+		case 7: // Goron's Ruby
+			text_print("Upgrades the Dash Ability",     left, info1);
+			text_print("to be faster",                  left, info2);
+			break;
+				
+		case 8: // Zora's Sapphire
+			text_print("Lower the magic cost of",       left, info1);
+			text_print("the dash ability",              left, info2);
+			break;
 	}
-	return 0;
+	text_flush(db);
+	
+	gDPSetPrimColor(db->p++, 0, 0, 0xFF, 0x00, 0x00, 0xFF);
+	text_print("Item:",                 left,     15);
+	text_print("Ability:",              left,     35);
+	text_print(medallion_item[show],    leftInfo, 15);
+	text_print(medallion_ability[show], leftInfo, 35);
+	
+	text_flush(db);
+	gDPFullSync(db->p++);
+	gSPEndDisplayList(db->p++);
+		
+	return 1;
 }
 
 void handle_inventory_editor() {
@@ -518,7 +518,7 @@ void handle_inventory_editor() {
 	
 	if (pad_pressed.a || pad_pressed.b) {
 		z64_game.pause_ctxt.unk_02_[1] = 3;
-		z64_playsfx(0x4814, (z64_xyzf_t*)0x80104394, 0x04, (float*)0x801043A0, (float*)0x801043A0, (float*)0x801043A8);
+		play_sfx = 0x4814;
 	}
 	
 	if (z64_x_axis_input > -10 && z64_x_axis_input < 10 && z64_y_axis_input > -10 && z64_y_axis_input < 10)

--- a/ASM/c/options.h
+++ b/ASM/c/options.h
@@ -10,6 +10,7 @@
 void toggle_options_menu();
 void handle_options_menu();
 void handle_options_menu_input(pad_t pad_pressed);
+uint8_t write_option(uint8_t save, uint8_t sram, uint8_t shift, pad_t pad_pressed);
 uint8_t draw_settings_menu(z64_disp_buf_t *db);
 uint8_t draw_abilities_info(z64_disp_buf_t *db);
 void handle_inventory_editor();

--- a/ASM/c/z64_extended.h
+++ b/ASM/c/z64_extended.h
@@ -72,6 +72,7 @@ typedef enum {
 	COLOR_KOKIRI		= 0x0,
 	COLOR_GORON			= 0x1,
 	COLOR_ZORA			= 0x2,
+	COLOR_NONE			= 0x3,
 	COLOR_FOREST		= 0x10,
 	COLOR_FIRE			= 0x4,
 	COLOR_WATER			= 0x5,
@@ -80,10 +81,8 @@ typedef enum {
 
 typedef enum {
 	OPTIONS_SIZE_CORE	= 9,
-	OPTIONS_SIZE_MAIN	= 17,
-	OPTIONS_SIZE_ALL	= 24,
-	OPTIONS_LENGTH		= 17,
-	OPTIONS_ROWS		= 13,
+	OPTIONS_SIZE_MAIN	= 18,
+	OPTIONS_SIZE_ALL	= 25,
 	
 	OPTION_30_FPS		= 0,
 	OPTION_DPAD,
@@ -95,6 +94,7 @@ typedef enum {
 	OPTION_KEEP_MASK,
 	OPTION_TRISWIPE,
 	
+	OPTION_DAMAGE_TAKEN,
 	OPTION_UNEQUIP_ITEM,
 	OPTION_UNEQUIP_GEAR,
 	OPTION_ITEM_ON_B,
@@ -129,7 +129,6 @@ typedef struct {
 } z64_capacity_t;
 
 /* Functions */
-#define z64_playsfx						((playsfx_t)			0x800C806C)
 #define z64_usebutton					((usebutton_t)			0x8038C9A0)
 
 /* DRAM addresses & data */
@@ -150,6 +149,9 @@ typedef struct {
 #define z64_link_a_action				(*(uint16_t*)			0x801DAA90)
 #define z64_idle_camera_counter			(*(uint8_t*)			0x801C86CF)
 #define z64_inventory_editor_index		(*(uint8_t*)			0x8039EA59)
+#define z64_damage_taken_modifier_1		(*(uint32_t*)			0x8038E5D0)
+#define z64_damage_taken_modifier_2		(*(uint32_t*)			0x8038E5D8)
+#define z64_damage_taken_modifier_3		(*(uint16_t*)			0x8038E5EA)
 
 /* DRAM addresses & data for HUD */
 #define z64_b_button_label_x			(*(uint16_t*)			0x801C7C3A)
@@ -173,6 +175,7 @@ typedef struct {
 /* DRAM addresses & data for Medallion Abilities */
 #define z64_tunic_color					(*(uint8_t*)			0x801DAB6C)
 #define z64_move_speed					(*(uint16_t*)			0x801DB258)
+#define z64_max_move_speed				(*(uint16_t*)			0x801DB2A0)
 #define z64_damage_frames				(*(uint8_t*)			0x801DB498)
 #define z64_sword_damage_1				(*(uint8_t*)			0x801DAF1E)
 #define z64_sword_damage_2				(*(uint8_t*)			0x801DAF9E)
@@ -231,8 +234,8 @@ typedef struct {
 #define DPAD_CHILD_SET1_LEFT			( (DPAD_CHILD_LEFT >> 4) & 0xF)
 #define DPAD_CHILD_SET2_LEFT			(DPAD_CHILD_LEFT & 0xF)
 
-/* Extra saving for Redux */
-#define EXTRA_SRAM_1					(*(uint8_t*)			0x8011B4FE)
+/* Extra saving for Redux (8011B4C8) */
+#define EXTRA_SRAM_1					(*(uint8_t*)			0x8011B4FE) // 0x37
 #define DPAD_INIT_SETUP					  (EXTRA_SRAM_1 & 1)
 #define DOWNGRADE_GIANTS_KNIFE			( (EXTRA_SRAM_1 & 2)    >> 1)
 #define DOWNGRADE_OCARINA				( (EXTRA_SRAM_1 & 4)    >> 2)
@@ -242,7 +245,7 @@ typedef struct {
 #define SAVE_NO_IDLE_CAMERA				( (EXTRA_SRAM_1 & 0x40) >> 6)
 #define SAVE_EXTRA_ABILITIES			( (EXTRA_SRAM_1 & 0x80) >> 7)
 
-#define EXTRA_SRAM_2					(*(uint8_t*)			0x8011B4FF)
+#define EXTRA_SRAM_2					(*(uint8_t*)			0x8011B4FF) // 0x38
 #define SAVE_UNEQUIP_GEAR				  (EXTRA_SRAM_2 & 1)
 #define SAVE_UNEQUIP_ITEM				( (EXTRA_SRAM_2 & 2)    >> 1)
 #define SAVE_ITEM_ON_B					( (EXTRA_SRAM_2 & 4)    >> 2)
@@ -252,21 +255,27 @@ typedef struct {
 #define SAVE_KEEP_MASK					( (EXTRA_SRAM_2 & 0x40) >> 6)
 #define SAVE_TRISWIPE					( (EXTRA_SRAM_2 & 0x80) >> 7)
 
-#define EXTRA_SRAM_3					(*(uint8_t*)			0x8011B500)
+#define EXTRA_SRAM_3					(*(uint8_t*)			0x8011B500) // 0x39
 #define SAVE_RUPEE_DRAIN				  (EXTRA_SRAM_3 & 15)
 #define SAVE_HIDE_HUD					( (EXTRA_SRAM_3 & 0x70) >> 4)
 #define SAVE_INFINITE_HP				( (EXTRA_SRAM_3 & 0x80) >> 7)
 
-#define EXTRA_SRAM_4					(*(uint8_t*)			0x8011B501)
+#define EXTRA_SRAM_4					(*(uint8_t*)			0x8011B501) // 0x3A
 #define SAVE_DPAD						  (EXTRA_SRAM_4 & 0x3)
 #define SAVE_SHOW_DPAD					( (EXTRA_SRAM_4 & 0xC)  >> 2)
 #define SAVE_HUD_LAYOUT					( (EXTRA_SRAM_4 & 0x70) >> 4)
 #define SAVE_INFINITE_MP				( (EXTRA_SRAM_4 & 0x80) >> 7)
 
-#define EXTRA_SRAM_5					(*(uint8_t*)			0x8011B4F2)
+#define EXTRA_SRAM_5					(*(uint8_t*)			0x8011B4F2) // 0x2B
 #define SAVE_FOG						  (EXTRA_SRAM_5 & 15)
 #define SAVE_LEVITATION					( (EXTRA_SRAM_5 & 0x10) >> 4)
 #define SAVE_INFINITE_RUPEES			( (EXTRA_SRAM_5 & 0x20) >> 5)
 #define SAVE_INFINITE_AMMO				( (EXTRA_SRAM_5 & 0x40) >> 6)
+
+#define EXTRA_SRAM_6					(*(uint8_t*)			0x8011B4F9) // 0x31
+#define SAVE_DAMAGE_TAKEN				  (EXTRA_SRAM_6 & 7)
+
+#define MAX_SWORD_HEALTH				(*(uint8_t*)			0x8038E1A3)
+#define SWORD_HEALTH					(*(uint8_t*)			0x8011B4F8) // 0x30
 
 #endif


### PR DESCRIPTION
- D-Pad now hides properly during cutscenes
- Hidden D-Pad still shows in Pause Screen on the Left Side
- Lens of Truth behavior is fixed when toggling the D-Pad on or off
- Typo fixes
- Silver Tunic now cut damage taken in half, rather than restore half of the lost damage
- New damage taken option
- Dash ability considers Link's maximum speed, in case you would increase his base speed
- Option digits can show up to 99 instead of 19
- Unequip tunic with the D-Pad
- No Tunic Medallion color
- More